### PR TITLE
remove settings when value is not set

### DIFF
--- a/manifests/config/roles.pp
+++ b/manifests/config/roles.pp
@@ -14,34 +14,75 @@ define icingaweb2::config::roles (
     path    => "${::icingaweb2::config_dir}/roles.ini",
   }
 
-  ini_setting { "icingaweb2 roles ${title} users":
-    section => $role_name,
-    setting => 'users',
-    value   => "\"${role_users}\"",
+  if $role_users {
+    ini_setting { "icingaweb2 roles ${title} users":
+      section => $role_name,
+      setting => 'users',
+      value   => "\"${role_users}\"",
+    }
+  } else {
+    ini_setting { "icingaweb2 roles ${title} users":
+      ensure  => absent,
+      section => $role_name,
+      setting => 'users',
+    }
   }
 
-  ini_setting { "icingaweb2 roles ${title} groups":
-    section => $role_name,
-    setting => 'groups',
-    value   => "\"${role_groups}\"",
+  if $role_groups {
+    ini_setting { "icingaweb2 roles ${title} groups":
+      section => $role_name,
+      setting => 'groups',
+      value   => "\"${role_groups}\"",
+    }
+  } else {
+    ini_setting { "icingaweb2 roles ${title} groups":
+      ensure  => absent,
+      section => $role_name,
+      setting => 'groups',
+    }
+
   }
 
-  ini_setting { "icingaweb2 roles ${title} permissions":
-    section => $role_name,
-    setting => 'permissions',
-    value   => "\"${role_permissions}\"",
+  if $role_permissions {
+    ini_setting { "icingaweb2 roles ${title} permissions":
+      section => $role_name,
+      setting => 'permissions',
+      value   => "\"${role_permissions}\"",
+    }
+  } else {
+    ini_setting { "icingaweb2 roles ${title} permissions":
+      ensure  => absent,
+      section => $role_name,
+      setting => 'permissions',
+    }
   }
 
-  ini_setting { "icingaweb2 roles ${title} host filter":
-    section => $role_name,
-    setting => 'monitoring/hosts/filter',
-    value   => "\"${role_host_filter}\"",
+  if $role_host_filter {
+    ini_setting { "icingaweb2 roles ${title} host filter":
+      section => $role_name,
+      setting => 'monitoring/hosts/filter',
+      value   => "\"${role_host_filter}\"",
+    }
+  } else {
+    ini_setting { "icingaweb2 roles ${title} host filter":
+      ensure  => absent,
+      section => $role_name,
+      setting => 'monitoring/hosts/filter',
+    }
   }
 
-  ini_setting { "icingaweb2 roles ${title} service filter":
-    section => $role_name,
-    setting => 'monitoring/services/filter',
-    value   => "\"${role_service_filter}\"",
+  if $role_service_filter {
+    ini_setting { "icingaweb2 roles ${title} service filter":
+      section => $role_name,
+      setting => 'monitoring/services/filter',
+      value   => "\"${role_service_filter}\"",
+    }
+  } else {
+    ini_setting { "icingaweb2 roles ${title} service filter":
+      ensure  => absent,
+      section => $role_name,
+      setting => 'monitoring/services/filter',
+    }
   }
 }
 


### PR DESCRIPTION
If settings are not defined, this module creates lines with empty values in the config file. This PR ensures the lines to be absent. 