### PR TITLE
Add support for Scientific Linux in Yum repo

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -52,10 +52,20 @@ class icingaweb2::params {
       $pkg_list                          = ['icingaweb2']
       $pkg_repo_release_key              = 'http://packages.icinga.org/icinga.key'
       $pkg_repo_release_metadata_expire  = undef
-      $pkg_repo_release_url              = 'http://packages.icinga.org/epel/$releasever/release'
+
+      case $::operatingsystem {
+        'Scientific': {
+          $pkg_repo_release_url          = "http://packages.icinga.org/epel/${::operatingsystemmajrelease}/release"
+          $pkg_repo_snapshot_url         = "http://packages.icinga.org/epel/${::operatingsystemmajrelease}/snapshot"
+        }
+        default: {
+          $pkg_repo_release_url          = 'http://packages.icinga.org/epel/$releasever/release'
+          $pkg_repo_snapshot_url         = 'http://packages.icinga.org/epel/$releasever/snapshot'
+        }
+      }
+
       $pkg_repo_snapshot_key             = 'http://packages.icinga.org/icinga.key'
       $pkg_repo_snapshot_metadata_expire = '1d'
-      $pkg_repo_snapshot_url             = 'http://packages.icinga.org/epel/$releasever/snapshot'
       $web_root                          = '/usr/share/icingaweb2'
 
       $pkg_deps = [


### PR DESCRIPTION
The current `baseurl` for the Yum repo on RedHat family operating systems uses:  `http://packages.icinga.org/epel/$releasever/release`

Unfortunately, this doesn't work on Scientific Linux because `$releasever` resolves to "major.minor" on Scientific Linux.  On RedHat, it resolves to "major" or "majorServer".

http://packages.icinga.org/epel/ does not have a "major.minor" structure, so the Yum repo fails on Scientific Linux.

If Icinga could create symlinks there for "major.minor" (e.g. 6.6 -> 6) or something, that'd resolve it.  Otherwise, something like what's in this pull request will resolve it.