### PR TITLE
Allowing to purge the confiruration directory

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -1,8 +1,9 @@
 # == Class icingaweb2::config
 #
 class icingaweb2::config (
-  $config_dir = $::icingaweb2::config_dir,
-  $web_root   = $::icingaweb2::web_root,
+  $config_dir       = $::icingaweb2::config_dir,
+  $config_dir_purge = $::icingaweb2::config_dir_purge,
+  $web_root         = $::icingaweb2::web_root,
 ) {
   @user { 'icingaweb2':
     ensure     => present,
@@ -29,6 +30,7 @@ class icingaweb2::config (
     $::icingaweb2::config_dir:
       ensure  => directory,
       mode    => $::icingaweb2::config_dir_mode,
+      purge   => $::icingaweb2::config_dir_purge,
       recurse => $::icingaweb2::config_dir_recurse;
 
     "${::icingaweb2::config_dir}/enabledModules":
@@ -146,4 +148,3 @@ class icingaweb2::config (
     }
   }
 }
-

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -18,6 +18,10 @@
 # $config_dir_mode::      Posix file mode for configuration directories.
 #                         Default: 0755.
 #
+# $config_dir_purge::     The $config_dir is purge at each puppet run.
+#                         Unmanaged puppet file will be lost
+#                         Default: false.
+#
 # $config_dir_recurse::   Apply the same posix permissions as $config_dir to any
 #                         directory contained in $config_dir.
 #                         Default: false.
@@ -167,6 +171,7 @@ class icingaweb2 (
   $auth_resource                     = $::icingaweb2::params::auth_resource,
   $config_dir                        = $::icingaweb2::params::config_dir,
   $config_dir_mode                   = $::icingaweb2::params::config_dir_mode,
+  $config_dir_purge                  = $::icingaweb2::params::config_dir_purge,
   $config_dir_recurse                = $::icingaweb2::params::config_dir_recurse,
   $config_file_mode                  = $::icingaweb2::params::config_file_mode,
   $config_group                      = $::icingaweb2::params::config_group,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -44,6 +44,7 @@ class icingaweb2::params {
     'RedHat': {
       $config_dir                        = '/etc/icingaweb2'
       $config_dir_mode                   = '0755'
+      $config_dir_purge                  = false
       $config_dir_recurse                = false
       $config_file_mode                  = '0664'
       $config_group                      = 'icingaweb2'
@@ -81,6 +82,7 @@ class icingaweb2::params {
     'Debian': {
       $config_dir                        = '/etc/icingaweb2'
       $config_dir_mode                   = '0755'
+      $config_dir_purge                  = false
       $config_dir_recurse                = false
       $config_file_mode                  = '0644'
       $config_group                      = 'icingaweb2'


### PR DESCRIPTION
This pull request enable the purge options in the icingaweb2::config. This allow puppet to run in an idempotent fashion removing all non puppet-managed resources.