### PR TITLE
Added LDAP auth_backend

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -73,6 +73,13 @@ class icingaweb2::config (
         auth_section  => 'icingaweb2',
       }
     }
+    'ldap', 'msldap': {
+      icingaweb2::config::authentication_ldap { 'LDAP Authentication':
+        auth_section  => 'icingaweb2',
+        auth_resource => $::icingaweb2::auth_resource,
+        auth_backend  => $::icingaweb2::auth_backend,
+      }
+    }
     default: {}
   }
 

--- a/manifests/config/authentication_ldap.pp
+++ b/manifests/config/authentication_ldap.pp
@@ -1,0 +1,26 @@
+# Define for setting IcingaWeb2 Authentication
+#
+define icingaweb2::config::authentication_ldap (
+  $auth_resource = undef,
+  $auth_section  = undef,
+  $auth_backend  = undef,
+) {
+  Ini_Setting {
+    ensure  => present,
+    require => File["${::icingaweb2::config_dir}/authentication.ini"],
+    path    => "${::icingaweb2::config_dir}/authentication.ini",
+  }
+
+  ini_setting { "icingaweb2 authentication ${title} resource":
+    section => $auth_section,
+    setting => 'resource',
+    value   => "\"${auth_resource}\"",
+  }
+
+  ini_setting { "icingaweb2 authentication ${title} backend":
+    section => $auth_section,
+    setting => 'backend',
+    value   => "\"${auth_backend}\"",
+  }
+}
+


### PR DESCRIPTION
The management of configuration.ini only had support for 'db' and 'external types'. 
This adds support for ldap and msldap so that icingaweb2::config::resource_ldap defined type may be used. 