### PR TITLE
Update graphite module on each puppet run

### DIFF
--- a/manifests/mod/graphite.pp
+++ b/manifests/mod/graphite.pp
@@ -63,7 +63,7 @@ class icingaweb2::mod::graphite (
     }
 
     vcsrepo { 'graphite':
-      ensure   => present,
+      ensure   => latest,
       path     => "${web_root}/modules/graphite",
       provider => 'git',
       revision => $git_revision,


### PR DESCRIPTION
Currently, the graphite git repo is checked out and then never touched again. This change will result in a `git pull` on each puppet run.