### PR TITLE
Update the Graphite module class.

### DIFF
--- a/manifests/mod/graphite.pp
+++ b/manifests/mod/graphite.pp
@@ -5,8 +5,8 @@ class icingaweb2::mod::graphite (
   $git_revision           = undef,
   $graphite_base_url      = 'http://graphite.com/render?',
   $graphite_metric_prefix = undef,
-  $service_name_template  = 'icinga2.$host.name$.services.$service.name$.$service.check_command$.perfdata.$metric$.value',
-  $host_name_template     = 'icinga2.$host.name$.host.$host.check_command$.perfdata.$metric$.value',
+  $service_name_template  = undef,
+  $host_name_template     = undef,
   $install_method         = 'git',
   $pkg_deps               = undef,
   $pkg_ensure             = 'present',
@@ -58,16 +58,20 @@ class icingaweb2::mod::graphite (
     }
   }
 
-  ini_setting { 'service_name_template':
-    section => 'graphite',
-    setting => 'service_name_template',
-    value   => $service_name_template,
+  if $service_name_template {
+    ini_setting { 'service_name_template':
+      section => 'graphite',
+      setting => 'service_name_template',
+      value   => $service_name_template,
+    }
   }
 
-  ini_setting { 'host_name_template':
-    section => 'graphite',
-    setting => 'host_name_template',
-    value   => $host_name_template,
+  if $host_name_template {
+    ini_setting { 'host_name_template':
+      section => 'graphite',
+      setting => 'host_name_template',
+      value   => $host_name_template,
+    }
   }
 
 

--- a/manifests/mod/graphite.pp
+++ b/manifests/mod/graphite.pp
@@ -4,7 +4,9 @@ class icingaweb2::mod::graphite (
   $git_repo               = 'https://github.com/philiphoy/icingaweb2-module-graphite.git',
   $git_revision           = undef,
   $graphite_base_url      = 'http://graphite.com/render?',
-  $graphite_metric_prefix = 'icinga',
+  $graphite_metric_prefix = undef,
+  $service_name_template  = 'icinga2.$host.name$.services.$service.name$.$service.check_command$.perfdata.$metric$.value',
+  $host_name_template     = 'icinga2.$host.name$.host.$host.check_command$.perfdata.$metric$.value',
   $install_method         = 'git',
   $pkg_deps               = undef,
   $pkg_ensure             = 'present',
@@ -48,11 +50,26 @@ class icingaweb2::mod::graphite (
     value   => $graphite_base_url,
   }
 
-  ini_setting { 'metric_prefix':
-    section => 'graphite',
-    setting => 'metric_prefix',
-    value   => $graphite_metric_prefix,
+  if $graphite_metric_prefix {
+    ini_setting { 'metric_prefix':
+      section => 'graphite',
+      setting => 'metric_prefix',
+      value   => $graphite_metric_prefix,
+    }
   }
+
+  ini_setting { 'service_name_template':
+    section => 'graphite',
+    setting => 'service_name_template',
+    value   => $service_name_template,
+  }
+
+  ini_setting { 'host_name_template':
+    section => 'graphite',
+    setting => 'host_name_template',
+    value   => $host_name_template,
+  }
+
 
   if $install_method == 'git' {
     if $pkg_deps {

--- a/spec/classes/icingaweb2_mod_graphite_spec.rb
+++ b/spec/classes/icingaweb2_mod_graphite_spec.rb
@@ -74,6 +74,38 @@ describe 'icingaweb2::mod::graphite', :type => :class do
     }
   end
 
+
+  describe 'with parameter: service_name_template' do
+    let (:params) {
+      {
+        :service_name_template=> '_service_name_template_'
+      }
+    }
+
+    it { should contain_ini_setting('service_name_template').with(
+        'section' => /graphite/,
+        'setting' => /service_name_template/,
+        'value'   => /_service_name_template_/
+      )
+    }
+  end
+
+
+  describe 'with parameter: host_name_template' do
+    let (:params) {
+      {
+        :host_name_template=> '_host_name_template_'
+      }
+    }
+
+    it { should contain_ini_setting('host_name_template').with(
+        'section' => /graphite/,
+        'setting' => /host_name_template/,
+        'value'   => /_host_name_template_/
+      )
+    }
+  end
+
   describe 'with parameter: install_method' do
     let (:params) {
       {


### PR DESCRIPTION
- Add parameters to the icingaweb2 graphite module class to manage the
  template parameters.
- Set the metric_prefix parameter to undef by default since this option
  has been removed from newer version of the module.