### PR TITLE
Add parameter manage_user

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -5,19 +5,22 @@ class icingaweb2::config (
   $config_dir_purge = $::icingaweb2::config_dir_purge,
   $web_root         = $::icingaweb2::web_root,
 ) {
-  @user { 'icingaweb2':
-    ensure     => present,
-    home       => $::icingaweb2::web_root,
-    managehome => true,
-  }
 
-  @group { 'icingaweb2':
-    ensure => present,
-    system => true,
-  }
+  if $::icingaweb2::manage_user {
+    @user { 'icingaweb2':
+      ensure     => present,
+      home       => $::icingaweb2::web_root,
+      managehome => true,
+    }
 
-  realize(User['icingaweb2'])
-  realize(Group['icingaweb2'])
+    @group { 'icingaweb2':
+      ensure => present,
+      system => true,
+    }
+
+    realize(User['icingaweb2'])
+    realize(Group['icingaweb2'])
+  }
 
   File {
     require => Class['::icingaweb2::install'],

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -89,6 +89,11 @@
 # $manage_repo::          Add a custom package repository.
 #                         Default: false.
 #
+# $manage_user::          Defines if user and group should be managed
+#                         by this module. Set to false if you don't want
+#                         user and group to be managed by this module.
+#                         Default: true.
+#
 # $pkg_deps::             Any dependencies that need to be resolved before
 #                         installing the main package.
 #                         Default: operating system specific.
@@ -195,6 +200,7 @@ class icingaweb2 (
   $log_store                         = $::icingaweb2::params::log_store,
   $manage_apache_vhost               = $::icingaweb2::params::manage_apache_vhost,
   $manage_repo                       = $::icingaweb2::params::manage_repo,
+  $manage_user                       = $::icingaweb2::params::manage_user,
   $pkg_deps                          = $::icingaweb2::params::pkg_deps,
   $pkg_ensure                        = $::icingaweb2::params::pkg_ensure,
   $pkg_list                          = $::icingaweb2::params::pkg_list,
@@ -233,6 +239,7 @@ class icingaweb2 (
   validate_array($pkg_list)
   validate_bool($config_dir_recurse)
   validate_bool($manage_repo)
+  validate_bool($manage_user)
   validate_bool($initialize)
   validate_slength($config_dir_mode, 4)
   validate_slength($config_file_mode, 4)

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -7,6 +7,7 @@ class icingaweb2::params {
   $install_method      = 'git'
   $manage_apache_vhost = false
   $manage_repo         = false
+  $manage_user         = true
 
   # Template variables
   $admin_permissions = '*'

--- a/spec/classes/icingaweb2_spec.rb
+++ b/spec/classes/icingaweb2_spec.rb
@@ -382,6 +382,22 @@ describe 'icingaweb2', :type => :class do
     end
   end
 
+  describe 'icingaweb2::manage_user' do
+    context 'with manage_user => true' do
+      let (:params) { { :manage_user => true } }
+
+      it { should contain_user('icingaweb2') }
+      it { should contain_group('icingaweb2') }
+    end
+
+    context 'with manage_user => false' do
+      let (:params) { { :manage_user => false } }
+
+      it { should_not contain_user('icingaweb2') }
+      it { should_not contain_group('icingaweb2') }
+    end
+  end
+
   describe 'with parameter: pkg_ensure' do
     let (:params) {
       {


### PR DESCRIPTION
This parameter defines if user and group should be managed by this module. This gives you the possibility to manage the user and group with another module or manually.

The default value is set to true so it doesn't change the existent behaviour of this module.

Rspec tests for icingaweb2::manage_user are added.