### PR TITLE
Change sql_schema_location if using git

### DIFF
--- a/manifests/initialize.pp
+++ b/manifests/initialize.pp
@@ -7,9 +7,15 @@ class icingaweb2::initialize {
     case $::operatingsystem {
       'RedHat', 'CentOS': {
         case $::icingaweb2::web_db {
+          if $::icingaweb2::install_method == 'git' {
+            $sql_schema_location = '/usr/share/icingaweb2/etc/schema/mysql.schema.sql'
+          } else {
+            $sql_schema_location = '/usr/share/doc/icingaweb2/schema/mysql.schema.sql'
+          }
+        
           'mysql': {
             exec { 'create db scheme':
-              command => "mysql --defaults-file='/root/.my.cnf' ${::icingaweb2::web_db_name} < /usr/share/doc/icingaweb2/schema/mysql.schema.sql",
+              command => "mysql --defaults-file='/root/.my.cnf' ${::icingaweb2::web_db_name} < ${sql_schema_location}",
               unless  => "mysql --defaults-file='/root/.my.cnf' ${::icingaweb2::web_db_name} -e \"SELECT 1 FROM icingaweb_user LIMIT 1;\"",
               notify  => Exec['create web user']
             }


### PR DESCRIPTION
The git clone does not create the docs folder, so this fails:

```
/Stage[main]/Icingaweb2::Initialize/Exec[create db scheme]/returns: sh: /usr/share/doc/icingaweb2/schema/mysql.schema.sql: No such file or directory
==> default: Error: mysql --defaults-file='/root/.my.cnf' icingaweb2 < /usr/share/doc/icingaweb2/schema/mysql.schema.sql returned 1 instead of one of [0]
```

This checks if the user is using the git installation method, then changes to the location of the correct schema.