### PR TITLE
Change sql_schema_location if using git

### DIFF
--- a/manifests/initialize.pp
+++ b/manifests/initialize.pp
@@ -8,8 +8,15 @@ class icingaweb2::initialize {
       'RedHat', 'CentOS': {
         case $::icingaweb2::web_db {
           'mysql': {
+
+            if $::icingaweb2::install_method == 'git' {
+              $sql_schema_location = '/usr/share/icingaweb2/etc/schema/mysql.schema.sql'
+            } else {
+              $sql_schema_location = '/usr/share/doc/icingaweb2/schema/mysql.schema.sql'
+            }
+
             exec { 'create db scheme':
-              command => "mysql --defaults-file='/root/.my.cnf' ${::icingaweb2::web_db_name} < /usr/share/doc/icingaweb2/schema/mysql.schema.sql",
+              command => "mysql --defaults-file='/root/.my.cnf' ${::icingaweb2::web_db_name} < ${sql_schema_location}",
               unless  => "mysql --defaults-file='/root/.my.cnf' ${::icingaweb2::web_db_name} -e \"SELECT 1 FROM icingaweb_user LIMIT 1;\"",
               notify  => Exec['create web user']
             }

--- a/spec/classes/icingaweb2_spec.rb
+++ b/spec/classes/icingaweb2_spec.rb
@@ -282,10 +282,20 @@ describe 'icingaweb2', :type => :class do
 
   describe 'with parameter: initialize => true' do
     context 'Distro: CentOS' do
-      let (:params) { { :initialize => true } }
-      let (:facts) { centos_facts }
+      context 'install_method => git' do
+        let (:params) { { :initialize => true, :install_method => 'git' } }
+        let (:facts) { centos_facts }
 
-      it { should contain_icingaweb2__initialize }
+        it { should contain_icingaweb2__initialize }
+        it { should contain_exec('create db scheme').with_command("mysql --defaults-file='/root/.my.cnf' icingaweb2 < /usr/share/icingaweb2/etc/schema/mysql.schema.sql") }
+      end
+      context 'install_method => package' do
+        let (:params) { { :initialize => true, :install_method => 'package' } }
+        let (:facts) { centos_facts }
+
+        it { should contain_icingaweb2__initialize }
+        it { should contain_exec('create db scheme').with_command("mysql --defaults-file='/root/.my.cnf' icingaweb2 < /usr/share/doc/icingaweb2/schema/mysql.schema.sql") }
+      end
     end
   end
 


### PR DESCRIPTION
The git clone does not create the docs folder, so this fails:

```
/Stage[main]/Icingaweb2::Initialize/Exec[create db scheme]/returns: sh: /usr/share/doc/icingaweb2/schema/mysql.schema.sql: No such file or directory
==> default: Error: mysql --defaults-file='/root/.my.cnf' icingaweb2 < /usr/share/doc/icingaweb2/schema/mysql.schema.sql returned 1 instead of one of [0]
```

This checks if the user is using the git installation method, then changes to the location of the correct schema.