### PR TITLE
Fix permissions

### DIFF
--- a/manifests/mod/monitoring.pp
+++ b/manifests/mod/monitoring.pp
@@ -11,6 +11,16 @@ class icingaweb2::mod::monitoring (
     mode  => $::icingaweb2::config_file_mode,
   }
 
+  $monitoring_mod_files = [
+    "${::icingaweb2::config_dir}/modules/monitoring/backends.ini",
+    "${::icingaweb2::config_dir}/modules/monitoring/config.ini",
+    "${::icingaweb2::config_dir}/modules/monitoring/commandtransports.ini",
+  ]
+
+  file { $monitoring_mod_files:
+    ensure => present,
+  }
+
   file { "${::icingaweb2::config_dir}/modules/monitoring":
     ensure => directory,
     mode   => $::icingaweb2::config_dir_mode;

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -44,7 +44,7 @@ class icingaweb2::params {
   case $::osfamily {
     'RedHat': {
       $config_dir                        = '/etc/icingaweb2'
-      $config_dir_mode                   = '0755'
+      $config_dir_mode                   = '2770'
       $config_dir_purge                  = false
       $config_dir_recurse                = false
       $config_file_mode                  = '0664'

--- a/spec/classes/icingaweb2_mod_monitoring_spec.rb
+++ b/spec/classes/icingaweb2_mod_monitoring_spec.rb
@@ -9,6 +9,25 @@ describe 'icingaweb2::mod::monitoring', :type => :class do
   end
 
   describe 'without parameters' do
+
+    [
+      'backends',
+      'config',
+      'commandtransports',
+    ].each do | config_file |
+
+      it {
+        should contain_file("/etc/icingaweb2/modules/monitoring/#{config_file}.ini").
+          with(
+          {
+            'owner' =>  'icingaweb2',
+            'group' =>  'icingaweb2',
+            'mode'  =>  '0644',
+          }
+        )
+      }
+    end
+
     it { should contain_ini_setting('security settings').with(
         'section' => /security/,
         'setting' => /protected_customvars/,


### PR DESCRIPTION
Fixes permissions on config files

Before ini_file was used to create the files, but the permissions were incorrect and you'd get an error message: ![Error](https://cloud.githubusercontent.com/assets/1064715/13003982/91bfc7ea-d170-11e5-9eb4-4fc135140f83.png)