### PR TITLE
Changes permission to 2770

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -44,7 +44,7 @@ class icingaweb2::params {
   case $::osfamily {
     'RedHat': {
       $config_dir                        = '/etc/icingaweb2'
-      $config_dir_mode                   = '0755'
+      $config_dir_mode                   = '2770'
       $config_dir_purge                  = false
       $config_dir_recurse                = false
       $config_file_mode                  = '0664'


### PR DESCRIPTION
When using the icinga cli command to perform the installation, the permissions on the directory is 2770