### PR TITLE
Set LDAP default parameter encryption to none

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ tmtags
 *.sw[op]
 tags
 .idea/
+*.iml
 
 ## Bundler
 Gemfile.lock

--- a/manifests/config/resource_ldap.pp
+++ b/manifests/config/resource_ldap.pp
@@ -7,7 +7,7 @@ define icingaweb2::config::resource_ldap (
   $resource_name       = $title,
   $resource_port       = undef,
   $resource_root_dn    = undef,
-  $resource_encryption = undef,
+  $resource_encryption = 'none',
 ) {
   Ini_Setting {
     ensure  => present,

--- a/manifests/config/resource_ldap.pp
+++ b/manifests/config/resource_ldap.pp
@@ -1,12 +1,13 @@
 # Define for setting IcingaWeb2 LDAP Resource
 #
 define icingaweb2::config::resource_ldap (
-  $resource_bind_dn = undef,
-  $resource_bind_pw = undef,
-  $resource_host    = undef,
-  $resource_name    = $title,
-  $resource_port    = undef,
-  $resource_root_dn = undef,
+  $resource_bind_dn    = undef,
+  $resource_bind_pw    = undef,
+  $resource_host       = undef,
+  $resource_name       = $title,
+  $resource_port       = undef,
+  $resource_root_dn    = undef,
+  $resource_encryption = undef,
 ) {
   Ini_Setting {
     ensure  => present,
@@ -48,6 +49,12 @@ define icingaweb2::config::resource_ldap (
     section => $resource_name,
     setting => 'bind_pw',
     value   => "\"${resource_bind_pw}\"",
+  }
+
+  ini_setting { "icingaweb2 resources ${title} encryption":
+    section => $resource_name,
+    setting => 'encryption',
+    value   => "\"${resource_encryption}\"",
   }
 }
 


### PR DESCRIPTION
In order to use e.g. LDAPS, encryption has to be configured in the LDAP resource.
