### PR TITLE
Module graphite is not getting enabled

### DIFF
--- a/manifests/mod/graphite.pp
+++ b/manifests/mod/graphite.pp
@@ -73,6 +73,11 @@ class icingaweb2::mod::graphite (
       value   => $host_name_template,
     }
   }
+  
+  file { "${::icingaweb2::config_dir}/enabledModules/graphite":
+    ensure => link,
+    target => '/usr/share/icingaweb2/modules/graphite'
+  }
 
 
   if $install_method == 'git' {


### PR DESCRIPTION
When usting the `mod::graphite` class the module is not getting enabled. As in `mod::monitoring` this should be done.