### PR TITLE
Support DB initialization on Ubuntu and Debian

### DIFF
--- a/manifests/initialize.pp
+++ b/manifests/initialize.pp
@@ -5,7 +5,7 @@
 class icingaweb2::initialize {
   if $::icingaweb2::initialize {
     case $::operatingsystem {
-      'RedHat', 'CentOS': {
+      'RedHat', 'CentOS', 'Debian', 'Ubuntu': {
         case $::icingaweb2::web_db {
           'mysql': {
 
@@ -16,13 +16,13 @@ class icingaweb2::initialize {
             }
 
             exec { 'create db scheme':
-              command => "mysql --defaults-file='/root/.my.cnf' ${::icingaweb2::web_db_name} < ${sql_schema_location}",
-              unless  => "mysql --defaults-file='/root/.my.cnf' ${::icingaweb2::web_db_name} -e \"SELECT 1 FROM icingaweb_user LIMIT 1;\"",
+              command => "mysql -h ${::icingaweb2::web_db_host} -u${::icingaweb2::web_db_user} -p${::icingaweb2::web_db_pass} ${::icingaweb2::web_db_name} < ${sql_schema_location}",
+              unless  => "mysql -h ${::icingaweb2::web_db_host} -u${::icingaweb2::web_db_user} -p${::icingaweb2::web_db_pass} ${::icingaweb2::web_db_name} -e \"SELECT 1 FROM icingaweb_user LIMIT 1;\"",
               notify  => Exec['create web user']
             }
 
             exec { 'create web user':
-              command     => "mysql --defaults-file='/root/.my.cnf' ${::icingaweb2::web_db_name} -e \" INSERT INTO icingaweb_user (name, active, password_hash) VALUES ('icingaadmin', 1, '\\\$1\\\$EzxLOFDr\\\$giVx3bGhVm4lDUAw6srGX1');\"",
+              command     => "mysql -h ${::icingaweb2::web_db_host} -u${::icingaweb2::web_db_user} -p${::icingaweb2::web_db_pass} ${::icingaweb2::web_db_name} -e \" INSERT INTO icingaweb_user (name, active, password_hash) VALUES ('icingaadmin', 1, '\\\$1\\\$EzxLOFDr\\\$giVx3bGhVm4lDUAw6srGX1');\"",
               refreshonly => true,
             }
           }

--- a/manifests/initialize.pp
+++ b/manifests/initialize.pp
@@ -16,12 +16,14 @@ class icingaweb2::initialize {
             }
 
             exec { 'create db scheme':
+              path    => ['/usr/bin', '/usr/sbin', '/bin'],
               command => "mysql -h ${::icingaweb2::web_db_host} -u${::icingaweb2::web_db_user} -p${::icingaweb2::web_db_pass} ${::icingaweb2::web_db_name} < ${sql_schema_location}",
               unless  => "mysql -h ${::icingaweb2::web_db_host} -u${::icingaweb2::web_db_user} -p${::icingaweb2::web_db_pass} ${::icingaweb2::web_db_name} -e \"SELECT 1 FROM icingaweb_user LIMIT 1;\"",
               notify  => Exec['create web user']
             }
 
             exec { 'create web user':
+              path    => ['/usr/bin', '/usr/sbin', '/bin'],
               command     => "mysql -h ${::icingaweb2::web_db_host} -u${::icingaweb2::web_db_user} -p${::icingaweb2::web_db_pass} ${::icingaweb2::web_db_name} -e \" INSERT INTO icingaweb_user (name, active, password_hash) VALUES ('icingaadmin', 1, '\\\$1\\\$EzxLOFDr\\\$giVx3bGhVm4lDUAw6srGX1');\"",
               refreshonly => true,
             }

--- a/manifests/initialize.pp
+++ b/manifests/initialize.pp
@@ -5,7 +5,7 @@
 class icingaweb2::initialize {
   if $::icingaweb2::initialize {
     case $::operatingsystem {
-      'RedHat', 'CentOS', 'Debian', 'Ubuntu': {
+      'RedHat', 'CentOS': {
         case $::icingaweb2::web_db {
           'mysql': {
 
@@ -16,6 +16,30 @@ class icingaweb2::initialize {
             }
 
             exec { 'create db scheme':
+              command => "mysql --defaults-file='/root/.my.cnf' ${::icingaweb2::web_db_name} < ${sql_schema_location}",
+              unless  => "mysql --defaults-file='/root/.my.cnf' ${::icingaweb2::web_db_name} -e \"SELECT 1 FROM icingaweb_user LIMIT 1;\"",
+              notify  => Exec['create web user']
+            }
+
+            exec { 'create web user':
+              command     => "mysql --defaults-file='/root/.my.cnf' ${::icingaweb2::web_db_name} -e \" INSERT INTO icingaweb_user (name, active, password_hash) VALUES ('icingaadmin', 1, '\\\$1\\\$EzxLOFDr\\\$giVx3bGhVm4lDUAw6srGX1');\"",
+              refreshonly => true,
+            }
+          }
+
+          default: {
+            fail "DB type ${::icingaweb2::web_db} not supported yet"
+          }
+        }
+      }
+
+      'Debian', 'Ubuntu': {
+        case $::icingaweb2::web_db {
+          'mysql': {
+
+            $sql_schema_location = '/usr/share/icingaweb2/etc/schema/mysql.schema.sql'
+
+            exec { 'create db scheme':
               path    => ['/usr/bin', '/usr/sbin', '/bin'],
               command => "mysql -h ${::icingaweb2::web_db_host} -u${::icingaweb2::web_db_user} -p${::icingaweb2::web_db_pass} ${::icingaweb2::web_db_name} < ${sql_schema_location}",
               unless  => "mysql -h ${::icingaweb2::web_db_host} -u${::icingaweb2::web_db_user} -p${::icingaweb2::web_db_pass} ${::icingaweb2::web_db_name} -e \"SELECT 1 FROM icingaweb_user LIMIT 1;\"",
@@ -23,7 +47,7 @@ class icingaweb2::initialize {
             }
 
             exec { 'create web user':
-              path    => ['/usr/bin', '/usr/sbin', '/bin'],
+              path        => ['/usr/bin', '/usr/sbin', '/bin'],
               command     => "mysql -h ${::icingaweb2::web_db_host} -u${::icingaweb2::web_db_user} -p${::icingaweb2::web_db_pass} ${::icingaweb2::web_db_name} -e \" INSERT INTO icingaweb_user (name, active, password_hash) VALUES ('icingaadmin', 1, '\\\$1\\\$EzxLOFDr\\\$giVx3bGhVm4lDUAw6srGX1');\"",
               refreshonly => true,
             }
@@ -41,4 +65,3 @@ class icingaweb2::initialize {
     }
   }
 }
-


### PR DESCRIPTION
There 3 adjustments:
- Add Debian/Ubuntu in if statement
- Add `path` in order to avoid `not qualified and no path was specified` issue in puppet.
- specify host, user, password instead of `.my.cnf`. There are cases that icingaweb2 and database are located on difference servers. As far as I know, your `.my.cnf` is created from mysql module `::mysql::client`