### PR TITLE
Adding support to create ssh_resource config

### DIFF
--- a/manifests/config/resource_ssh.pp
+++ b/manifests/config/resource_ssh.pp
@@ -1,0 +1,33 @@
+# Define for setting IcingaWeb2 ssh Resource
+#
+define icingaweb2::config::resource_ssh (
+  $resource_user        = undef,
+  $resource_private_key = undef,
+  $resource_name        = $title,
+
+) {
+  Ini_Setting {
+    ensure  => present,
+    require => File["${::icingaweb2::config_dir}/resources.ini"],
+    path    => "${::icingaweb2::config_dir}/resources.ini",
+  }
+
+  ini_setting { "icingaweb2 resources ${title} type":
+    section => $resource_name,
+    setting => 'type',
+    value   => 'ssh',
+  }
+
+  ini_setting { "icingaweb2 resources ${title} db":
+    section => $resource_name,
+    setting => 'private_key',
+    value   => "\"${resource_private_key}\"",
+  }
+
+  ini_setting { "icingaweb2 resources ${title} host":
+    section => $resource_name,
+    setting => 'user',
+    value   => "\"${resource_user}\"",
+  }
+}
+


### PR DESCRIPTION
This adds support to create ssh_resources

example: 
  icingaweb2::config::resource_ssh { $ssh_resource_name:
    resource_user        => $ssh_resource_user,
    resource_private_key => $ssh_resource_private_key,
  }
