### PR TITLE
adding support for charset in database resource

### DIFF
--- a/manifests/config/resource_database.pp
+++ b/manifests/config/resource_database.pp
@@ -8,6 +8,7 @@ define icingaweb2::config::resource_database (
   $resource_password = undef,
   $resource_port     = undef,
   $resource_username = undef,
+  $resource_charset  = 'utf8',
 ) {
   Ini_Setting {
     ensure  => present,
@@ -55,6 +56,12 @@ define icingaweb2::config::resource_database (
     section => $resource_name,
     setting => 'password',
     value   => "\"${resource_password}\"",
+  }
+  
+  ini_setting { "icingaweb2 resources ${title} charset":
+    section => $resource_name,
+    setting => 'charset',
+    value   => "\"${resource_charset}\"",
   }
 }
 


### PR DESCRIPTION
This enables to add the "charset" option for a database resource. By default 'utf8'

example:

    create_resources(icingaweb2::config::resource_database, $director_db_resource)

``` yaml
profile::monitoring::web::director_db_resource:
  'director-db':
    resource_db: 'mysql'
    resource_dbname: 'icinga2director'
    resource_host: '127.0.0.1'
    resource_password: 'icinga'
    resource_port: '3306'
    resource_username: 'icingaweb2'
    resource_charset: 'utf8'
```