### PR TITLE
Create the icingaweb2 user with the system flag.

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -10,6 +10,7 @@ class icingaweb2::config (
     @user { 'icingaweb2':
       ensure     => present,
       home       => $::icingaweb2::web_root,
+      system     => true,
       managehome => true,
     }
 


### PR DESCRIPTION
- Without the system flag this could cause UID conflicts for some users.
- The group resource already uses the system flag so this adds consistency.
