### PR TITLE
remove dependency on concat module

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,7 +1,6 @@
 fixtures:
   repositories:
     apache:  'https://github.com/puppetlabs/puppetlabs-apache'
-    concat:  'https://github.com/puppetlabs/puppetlabs-concat'
     inifile: 'https://github.com/puppetlabs/puppetlabs-inifile'
     stdlib:  'https://github.com/puppetlabs/puppetlabs-stdlib'
     vcsrepo: 'https://github.com/puppetlabs/puppetlabs-vcsrepo'

--- a/metadata.json
+++ b/metadata.json
@@ -9,7 +9,6 @@
   "issues_url": "https://dev.icinga.org/projects/puppet-icingaweb2",
   "dependencies": [
     {"name":"puppetlabs/apache","version_requirement":">= 1.2.0 < 2.0.0"},
-    {"name":"puppetlabs/concat","version_requirement":">= 1.2.0 < 2.0.0"},
     {"name":"puppetlabs/inifile","version_requirement":">= 1.2.0 < 2.0.0"},
     {"name":"puppetlabs/stdlib","version_requirement":">= 4.4.0 < 5.0.0"},
     {"name":"puppetlabs/vcsrepo","version_requirement":">= 1.2.0 < 2.0.0"}

--- a/spec/classes/icingaweb2_mod_businessprocess_spec.rb
+++ b/spec/classes/icingaweb2_mod_businessprocess_spec.rb
@@ -1,7 +1,6 @@
 require 'spec_helper'
 
 describe 'icingaweb2::mod::businessprocess', :type => :class do
-  let (:pre_condition) { '$concat_basedir = "/tmp"' }
   let (:facts) { debian_facts }
 
   let :pre_condition do

--- a/spec/classes/icingaweb2_mod_deployment_spec.rb
+++ b/spec/classes/icingaweb2_mod_deployment_spec.rb
@@ -1,7 +1,6 @@
 require 'spec_helper'
 
 describe 'icingaweb2::mod::deployment', :type => :class do
-  let (:pre_condition) { '$concat_basedir = "/tmp"' }
   let (:facts) { debian_facts }
 
   let :pre_condition do

--- a/spec/classes/icingaweb2_mod_graphite_spec.rb
+++ b/spec/classes/icingaweb2_mod_graphite_spec.rb
@@ -1,7 +1,6 @@
 require 'spec_helper'
 
 describe 'icingaweb2::mod::graphite', :type => :class do
-  let (:pre_condition) { '$concat_basedir = "/tmp"' }
   let (:facts) { debian_facts }
 
   let :pre_condition do

--- a/spec/classes/icingaweb2_mod_monitoring_spec.rb
+++ b/spec/classes/icingaweb2_mod_monitoring_spec.rb
@@ -1,7 +1,6 @@
 require 'spec_helper'
 
 describe 'icingaweb2::mod::monitoring', :type => :class do
-  let (:pre_condition) { '$concat_basedir = "/tmp"' }
   let (:facts) { debian_facts }
 
   let :pre_condition do

--- a/spec/classes/icingaweb2_mod_nagvis_spec.rb
+++ b/spec/classes/icingaweb2_mod_nagvis_spec.rb
@@ -1,7 +1,6 @@
 require 'spec_helper'
 
 describe 'icingaweb2::mod::nagvis', :type => :class do
-  let (:pre_condition) { '$concat_basedir = "/tmp"' }
   let (:facts) { debian_facts }
 
   let :pre_condition do

--- a/spec/classes/icingaweb2_spec.rb
+++ b/spec/classes/icingaweb2_spec.rb
@@ -1,7 +1,6 @@
 require 'spec_helper'
 
 describe 'icingaweb2', :type => :class do
-  let (:pre_condition) { '$concat_basedir = "/tmp"' }
   let (:facts) { debian_facts }
   let (:params) {
     {
@@ -375,7 +374,6 @@ describe 'icingaweb2', :type => :class do
   end
 
   describe 'with parameter: manage_apache_vhost' do
-    let (:pre_condition) { '$concat_basedir = "/tmp"' }
     context 'manage_apache_vhost => true' do
       let (:params) { { :manage_apache_vhost => true } }
 
@@ -646,7 +644,6 @@ describe 'icingaweb2', :type => :class do
   end
 
   describe 'with parameter: web_root' do
-    let (:pre_condition) { '$concat_basedir = "/tmp"' }
     context 'default' do
       let (:params) { { :web_root => '/web/root' } }
 


### PR DESCRIPTION
This module doesn't use concat anymore. Removing this dependency is required for compatibility with https://github.com/Icinga/puppet-icinga2-rewrite since it requires a newer concat version.