### PR TITLE
Added groups.ini configuration

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -48,6 +48,9 @@ class icingaweb2::config (
     "${::icingaweb2::config_dir}/authentication.ini":
       ensure => file;
 
+    "${::icingaweb2::config_dir}/groups.ini":
+      ensure => file;
+
     "${::icingaweb2::config_dir}/config.ini":
       ensure => file;
 
@@ -87,6 +90,17 @@ class icingaweb2::config (
         user_name_attribute => $::icingaweb2::auth_ldap_user_name_attribute,
         filter              => $::icingaweb2::auth_ldap_filter,
         base_dn             => $::icingaweb2::auth_ldap_base_dn,
+      }
+    }
+    default: {}
+  }
+
+  # Configure groups.ini settings
+  case $::icingaweb2::groups_backend {
+    'db': {
+      icingaweb2::config::groups_database { 'Local Database Groups':
+        groups_section  => 'icingaweb2',
+        groups_resource => $::icingaweb2::groups_resource,
       }
     }
     default: {}

--- a/manifests/config/groups_database.pp
+++ b/manifests/config/groups_database.pp
@@ -1,0 +1,24 @@
+# Define for setting IcingaWeb2 Groups
+#
+define icingaweb2::config::groups_database (
+  $groups_resource = undef,
+  $groups_section  = undef,
+) {
+  Ini_Setting {
+    ensure  => present,
+    require => File["${::icingaweb2::config_dir}/groups.ini"],
+    path    => "${::icingaweb2::config_dir}/groups.ini",
+  }
+
+  ini_setting { "icingaweb2 groups ${title} resource":
+    section => $groups_section,
+    setting => 'resource',
+    value   => "\"${groups_resource}\"",
+  }
+
+  ini_setting { "icingaweb2 groups ${title} backend":
+    section => $groups_section,
+    setting => 'backend',
+    value   => '"db"',
+  }
+}

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -24,6 +24,12 @@
 # $auth_resource::
 #                         Default:
 #
+# $groups_backend::
+#                         Default:
+#
+# $groups_resource::
+#                         Default:
+#
 # $config_dir::           Location of the main configuration directory.
 #                         Default: operating system specific.
 #
@@ -161,6 +167,9 @@
 # $template_auth::
 #                         Default: icingaweb2/authentication.ini.erb
 #
+# $template_groups::
+#                         Default: icingaweb2/groups.ini.erb
+#
 # $template_config::
 #                         Default: icingaweb2/config.ini.erb
 #
@@ -211,6 +220,8 @@ class icingaweb2 (
   $auth_ldap_user_class              = $::icingaweb2::params::auth_ldap_user_class,
   $auth_ldap_user_name_attribute     = $::icingaweb2::params::auth_ldap_user_name_attribute,
   $auth_resource                     = $::icingaweb2::params::auth_resource,
+  $groups_backend                    = $::icingaweb2::params::groups_backend,
+  $groups_resource                   = $::icingaweb2::params::groups_resource,
   $config_dir                        = $::icingaweb2::params::config_dir,
   $config_dir_mode                   = $::icingaweb2::params::config_dir_mode,
   $config_dir_purge                  = $::icingaweb2::params::config_dir_purge,
@@ -253,6 +264,7 @@ class icingaweb2 (
   $pkg_repo_snapshot_url             = $::icingaweb2::params::pkg_repo_snapshot_url,
   $pkg_repo_version                  = $::icingaweb2::params::pkg_repo_version,
   $template_auth                     = $::icingaweb2::params::template_auth,
+  $template_groups                   = $::icingaweb2::params::template_groups,
   $template_config                   = $::icingaweb2::params::template_config,
   $template_resources                = $::icingaweb2::params::template_resources,
   $template_roles                    = $::icingaweb2::params::template_roles,
@@ -357,4 +369,3 @@ class icingaweb2 (
     ]
   )
 }
-

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -18,6 +18,8 @@ class icingaweb2::params {
   $auth_ldap_user_class          = 'inetOrgPerson'
   $auth_ldap_user_name_attribute = 'uid'
   $auth_resource                 = 'icingaweb_db'
+  $groups_backend                = 'db'
+  $groups_resource               = 'icingaweb_db'
   $ido_db                        = 'mysql'
   $ido_db_host                   = 'localhost'
   $ido_db_name                   = 'icingaweb2'
@@ -38,8 +40,9 @@ class icingaweb2::params {
   $log_store                     = 'db'
   $pkg_repo_version              = 'release'
   $template_auth                 = 'icingaweb2/authentication.ini.erb'
+  $template_groups               = 'icingaweb2/groups.ini.erb'
   $template_config               = 'icingaweb2/config.ini.erb'
-  $template_resources            ='icingaweb2/resources.ini.erb'
+  $template_resources            = 'icingaweb2/resources.ini.erb'
   $template_roles                = 'icingaweb2/roles.ini.erb'
   $template_apache               = 'icingaweb2/apache2.conf.erb'
   $web_db                        = 'mysql'
@@ -124,4 +127,3 @@ class icingaweb2::params {
     }
   }
 }
-

--- a/spec/classes/icingaweb2_spec.rb
+++ b/spec/classes/icingaweb2_spec.rb
@@ -21,6 +21,7 @@ describe 'icingaweb2', :type => :class do
 
     it { should contain_file('/etc/icingaweb2') }
     it { should contain_file('/etc/icingaweb2/authentication.ini') }
+    it { should contain_file('/etc/icingaweb2/groups.ini') }
     it { should contain_file('/etc/icingaweb2/config.ini') }
     it { should contain_file('/etc/icingaweb2/enabledModules') }
     it { should contain_file('/etc/icingaweb2/modules') }
@@ -82,6 +83,15 @@ describe 'icingaweb2', :type => :class do
     end
   end
 
+  describe 'with parameter: groups_backend' do
+    context 'groups_backend => db' do
+      let (:params) { { :groups_backend => 'db' } }
+      it {
+        should contain_icingaweb2__config__groups_database('Local Database Groups').with('groups_section' => 'icingaweb2')
+      }
+    end
+  end
+
   describe 'with parameter: auth_resource' do
     let (:params) {
       {
@@ -101,6 +111,7 @@ describe 'icingaweb2', :type => :class do
 
     it { should contain_file('/test/etc/icingaweb2') }
     it { should contain_file('/test/etc/icingaweb2/authentication.ini') }
+    it { should contain_file('/test/etc/icingaweb2/groups.ini') }
     it { should contain_file('/test/etc/icingaweb2/config.ini') }
     it { should contain_file('/test/etc/icingaweb2/enabledModules') }
     it { should contain_file('/test/etc/icingaweb2/modules') }
@@ -674,4 +685,3 @@ describe 'icingaweb2', :type => :class do
     end
   end
 end
-


### PR DESCRIPTION
Add the `groups.ini` config file to set up a user group backend. It defaults to db (same as for authentication)