### PR TITLE
Package managers handle dependencies.

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -7,13 +7,6 @@ class icingaweb2::install {
         ensure => $::icingaweb2::pkg_ensure,
       }
     }
-
-    if $::icingaweb2::pkg_deps {
-      package { $::icingaweb2::pkg_deps:
-        ensure => $::icingaweb2::pkg_ensure,
-        before => Package[$::icingaweb2::pkg_list],
-      }
-    }
   }
 
   if $::icingaweb2::install_method == 'git' {


### PR DESCRIPTION
There's no need to manually install dependencies when installing icingaweb2 as a package. The package manager will automatically pull the right packages in.

**Note: I have made an assumption this is true on RedHat too.**