### PR TITLE
Move from darin/zypprepo to puppet/zypprepo

### DIFF
--- a/.fixtures.puppet3.yml
+++ b/.fixtures.puppet3.yml
@@ -7,6 +7,6 @@ fixtures:
     apt:
       repo: "puppetlabs/apt"
       ref: "2.4.0"
-    zypprepo: "darin/zypprepo"
+    zypprepo: "puppet/zypprepo"
   symlinks:
     icingaweb2: "#{source_dir}"

--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -3,6 +3,6 @@ fixtures:
     stdlib: "puppetlabs/stdlib"
     concat: "puppetlabs/concat"
     apt: "puppetlabs/apt"
-    zypprepo: "darin/zypprepo"
+    zypprepo: "puppet/zypprepo"
   symlinks:
     icingaweb2: "#{source_dir}"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/Icinga/puppet-icingaweb2.png?branch=master)](https://travis-ci.org/Icinga/puppet-icingaweb2)
+
 
 # Icinga Web 2 Puppet Module
 
@@ -51,7 +51,7 @@ This module depends on
 Depending on your setup following modules may also be required:
 
 * [puppetlabs/apt] >= 2.0.0
-* [darin/zypprepo] >= 1.0.2
+* [puppet/zypprepo] >= 2.0.0
 
 ### Limitations
 
@@ -294,7 +294,7 @@ icingaweb2::config::groupbackend {'mysql-backend':
 
 #### Business Process
 
-#### Cube 
+#### Cube
 
 ## Reference
 
@@ -316,7 +316,7 @@ icingaweb2::config::groupbackend {'mysql-backend':
 ### Public Classes
 
 #### Class: `icingaweb2`
-The default class of this module. It handles the basic installation and configuration of Icinga Web 2. 
+The default class of this module. It handles the basic installation and configuration of Icinga Web 2.
 
 **Parameters of `icingaweb2`:**
 
@@ -363,7 +363,7 @@ Stores all default parameters for the Icinga Web 2 installation.
 
 #### Class: `icingaweb2::repo`
 Installs the [packages.icinga.com] repository. Depending on your operating system [puppetlabs/apt] or
-[darin/zypprepo] are required.
+[puppet/zypprepo] are required.
 
 ### Public Defined Types
 
@@ -555,7 +555,7 @@ See also [CHANGELOG.md]
 [Icinga Web 2]: https://www.icinga.com/products/icinga-web-2/
 
 [puppetlabs/apt]: https://github.com/puppetlabs/puppetlabs-apt
-[darin/zypprepo]: https://forge.puppet.com/darin/zypprepo
+[puppet/zypprepo]: https://forge.puppet.com/puppet/zypprepo
 [puppetlabs/stdlib]: https://github.com/puppetlabs/puppetlabs-stdlib
 [puppetlabs/concat]: https://github.com/puppetlabs/puppetlabs-concat
 [puppetlabs/vcsrepo]: https://forge.puppet.com/puppetlabs/vcsrepo

--- a/metadata.json
+++ b/metadata.json
@@ -16,7 +16,7 @@
     { "name":"puppetlabs/inifile","version_requirement":">= 1.5.0 < 2.0.0" },
     { "name":"puppetlabs/vcsrepo","version_requirement":">= 1.3.0 < 2.0.0" },
     { "name": "puppetlabs/apt", "version_requirement": ">= 2.0.0 < 5.0.0" },
-    { "name": "darin/zypprepo", "version_requirement": ">= 1.0.2 < 2.0.0" }
+    { "name": "puppet/zypprepo", "version_requirement": ">= 2.0.0 < 3.0.0" }
   ],
   "tags": [
     "icinga",


### PR DESCRIPTION
Once again, same as for puppet-icinga2 ;)

Otherwise you get dependency errors for the archaic version of puppet-concat

```
Conflict between puppetlabs-concat (< 3.0.0, >= 2.0.1) <(no source specified)> and puppetlabs-concat (< 2.0.0, >= 1.2.0) <https://forgeapi.puppetlabs.com>
``` 