### PR TITLE
Allow multiple commandtransports

### DIFF
--- a/README.md
+++ b/README.md
@@ -511,18 +511,8 @@ Username for IDO DB connection.
 ##### `ido_db_password`
 Password for IDO DB connection.
 
-##### `api_host`
-The API host is your Icinga 2.
-
-##### `api_port`
-Port of your Icinga 2 API. Defaults to `5665`
-
-##### `api_username`
-API username. This is needed to send commands to the Icinga 2 core Make sure you have a proper `ApiUser` configuration
-object configured in Icinga 2.
-
-##### `api_password`
-Password of the API user.
+##### `commandtransports`
+A hash of command transports.
 
 #### Class: `icingaweb2::module::director`
 Install and configure the director module.

--- a/manifests/module/monitoring/commandtransport.pp
+++ b/manifests/module/monitoring/commandtransport.pp
@@ -1,0 +1,80 @@
+# == Define: icingaweb2::module::monitoring::commandtransport
+#
+# Manage commandtransport configuration for the monitoring module
+#
+# === Parameters
+#
+# [*commandtransport*]
+#   The name of the commandtransport.
+#
+# [*transport*]
+#   The transport type you wish to use. Either `api` or `local`. Defaults to `api`
+#
+# [*host*]
+#   Hostname/ip for the transport. Only needed for api transport. Defaults to `localhost`
+#
+# [*port*]
+#   Port for the transport. Only needed for api transport. Defaults to `5665`
+#
+# [*username*]
+#   Username for the transport. Only needed for api transport.
+#
+# [*password*]
+#   Password for the transport. Only needed for api transport.
+#
+# [*path*]
+#   Path for the transport. Only needed for local transport. Defaults to `/var/run/icinga2/cmd/icinga2.cmd`
+#
+define icingaweb2::module::monitoring::commandtransport(
+  $commandtransport = $title,
+  $transport        = 'api',
+  $host             = 'localhost',
+  $port             = '5665',
+  $username         = undef,
+  $password         = undef,
+  $path             = '/var/run/icinga2/cmd/icinga2.cmd',
+){
+  assert_private("You're not supposed to use this defined type manually.")
+
+  $conf_dir        = $::icingaweb2::params::conf_dir
+  $module_conf_dir = "${conf_dir}/modules/monitoring"
+
+  validate_string($commandtransport)
+  validate_re($transport, ['api', 'local' ],
+    "${transport} isn't supported. Valid values are 'api' or 'local'.")
+
+  case $transport {
+    'api': {
+      validate_string($host)
+      validate_numeric($port)
+      validate_string($username)
+      validate_string($password)
+
+      $commandtransport_settings = {
+        'transport' => $transport,
+        'host'      => $host,
+        'port'      => $port,
+        'username'  => $username,
+        'password'  => $password,
+      }
+    }
+    'local': {
+      validate_absolute_path($path)
+
+      $commandtransport_settings = {
+        'transport' => $transport,
+        'path'      => $path,
+      }
+    }
+    default: {
+      fail('The transport type you provided is not supported')
+    }
+  }
+
+
+  icingaweb2::inisection { "monitoring-commandtransport-${commandtransport}":
+    section_name => $commandtransport,
+    target       => "${module_conf_dir}/commandtransports.ini",
+    settings     => delete_undef_values($commandtransport_settings),
+  }
+}

--- a/spec/classes/monitoring_spec.rb
+++ b/spec/classes/monitoring_spec.rb
@@ -10,14 +10,18 @@ describe('icingaweb2::module::monitoring', :type => :class) do
       facts
     end
 
-    context "#{os} with ido_type 'mysql'" do
+    context "#{os} with ido_type 'mysql' and commandtransport 'api'" do
       let(:params) { { :ido_type => 'mysql',
                        :ido_host => 'localhost',
                        :ido_db_name => 'icinga2',
                        :ido_db_username => 'icinga2',
                        :ido_db_password => 'icinga2',
-                       :api_username => 'root',
-                       :api_password => 'foobar' } }
+											 :commandtransports => {
+											   'foo' => {
+												   'username' => 'root',
+													 'password' => 'foobar',
+												 }
+											 } } }
 
 
       it { is_expected.to contain_icingaweb2__module('monitoring')
@@ -32,15 +36,54 @@ describe('icingaweb2::module::monitoring', :type => :class) do
                                    'resource'=>'icingaweb2-module-monitoring'
                                }
                            },
-                           'module-monitoring-commandtransports'=>{
-                               'section_name' => 'commandtransports',
-                               'target'=>'/etc/icingaweb2/modules/monitoring/commandtransports.ini',
+                           'module-monitoring-config'=>{
+                               'section_name' => 'config',
+                               'target'=>'/etc/icingaweb2/modules/monitoring/config.ini',
                                'settings'=>{
-                                   'transport'=>'api',
-                                   'host'=>'localhost',
-                                   'port'=>'5665',
-                                   'username'=>'root',
-                                   'password'=>'foobar'
+                                   'protected_customvars'=>'*pw*, *pass*, community'
+                               }
+                           }
+                       }) }
+
+			it { is_expected.to contain_icingaweb2__config__resource('icingaweb2-module-monitoring')
+				.with_type('db')
+				.with_db_type('mysql')
+				.with_host('localhost')
+				.with_port('3306')
+				.with_db_name('icinga2')
+				.with_db_username('icinga2')
+				.with_db_password('icinga2')
+			}
+
+			it { is_expected.to contain_icingaweb2__module__monitoring__commandtransport('foo')
+				.with_username('root')
+				.with_password('foobar')
+			}
+    end
+
+    context "#{os} with ido_type 'pgsql' and commandtransport 'local'" do
+      let(:params) { { :ido_type => 'pgsql',
+                       :ido_host => 'localhost',
+											 :ido_port => 5432,
+                       :ido_db_name => 'icinga2',
+                       :ido_db_username => 'icinga2',
+                       :ido_db_password => 'icinga2',
+											 :commandtransports => {
+											   'foo' => {
+												   'transport' => 'local',
+												 }
+											 } } }
+
+      it { is_expected.to contain_icingaweb2__module('monitoring')
+        .with_install_method('none')
+        .with_module_dir('/usr/share/icingaweb2/modules/monitoring')
+        .with_settings({
+                           'module-monitoring-backends'=>{
+                               'section_name' => 'backends',
+                               'target'=>'/etc/icingaweb2/modules/monitoring/backends.ini',
+                               'settings'=>{
+                                   'type'=>'ido',
+                                   'resource'=>'icingaweb2-module-monitoring'
                                }
                            },
                            'module-monitoring-config'=>{
@@ -51,6 +94,20 @@ describe('icingaweb2::module::monitoring', :type => :class) do
                                }
                            }
                        }) }
+
+			it { is_expected.to contain_icingaweb2__config__resource('icingaweb2-module-monitoring')
+				.with_type('db')
+				.with_db_type('pgsql')
+				.with_host('localhost')
+				.with_port(5432)
+				.with_db_name('icinga2')
+				.with_db_username('icinga2')
+				.with_db_password('icinga2')
+			}
+
+			it { is_expected.to contain_icingaweb2__module__monitoring__commandtransport('foo')
+				.with_transport('local')
+			}
     end
 
     context "#{os} with invalid ido_type" do


### PR DESCRIPTION
This commits adds support for muliple commandtransports. It also
implements a way to configure local command pipes as commandtransport.

Fixes #155