### PR TITLE
Removed puppetlabs-apache from dependencies

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -11,7 +11,6 @@
     { "name": "puppet", "version_requirement": ">= 4.7.0 < 6.0.0" }
   ],
   "dependencies": [
-    { "name":"puppetlabs/apache","version_requirement":">= 1.2.0 < 2.0.0" },
     { "name":"puppetlabs/stdlib","version_requirement":">= 4.16.0 < 5.0.0" },
     { "name": "puppetlabs/concat", "version_requirement": ">= 2.0.1 < 5.0.0" },
     { "name":"puppetlabs/vcsrepo","version_requirement":">= 1.3.0 < 2.0.0" },


### PR DESCRIPTION
As this module is no longer making use of apache2, there are no more reasons to keep it. 

It also blocks using this module for its archaic version dep on apache2.