### PR TITLE
Fix typos on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,9 +190,9 @@ mysql::db { 'icingaweb2':
 class {'icingaweb2':
   manage_repo   => true,
   import_schema => true,
-  db_type       => 'pgsql',
+  db_type       => 'mysql',
   db_host       => 'localhost',
-  db_port       => '5432',
+  db_port       => 3306,
   db_username   => 'icingaweb2',
   db_password   => 'icingaweb2',
   require       => Mysql::Db['icingaweb2'],


### PR DESCRIPTION
Fixed 3 typos in 2 lines:

Line 193, example is for mysql but had pgsql as the db_type, this causes example to fail.
Line 195, wrong port for mysql, had 5432 (postgresql) should be 3306 (mysql).
Line 195, port string was single quoted making it a STRING instead of the expected INTEGER.