### PR TITLE
Fix protected_customvars bugs and papercuts

### DIFF
--- a/README.md
+++ b/README.md
@@ -577,7 +577,7 @@ Manage the monitoring module. This module is mandatory for probably every setup.
 ##### `ensure`
 Enable or disable module. Defaults to `present`
 
-##### `pretected_customvars`
+##### `protected_customvars`
 Custom variables in Icinga 2 may contain sensible information. Set patterns for custom variables that should be hidden
 in the web interface. Defaults to `*pw*,*pass*,community`
 

--- a/README.md
+++ b/README.md
@@ -579,7 +579,7 @@ Enable or disable module. Defaults to `present`
 
 ##### `pretected_customvars`
 Custom variables in Icinga 2 may contain sensible information. Set patterns for custom variables that should be hidden
-in the web interface. Defaults to `*pw*, *pass*, community`
+in the web interface. Defaults to `*pw*,*pass*,community`
 
 ##### `ido_type`
 Type of your IDO database. Either `mysql` or `pgsql`. Defaults to `mysql`

--- a/manifests/module/monitoring.pp
+++ b/manifests/module/monitoring.pp
@@ -73,7 +73,7 @@ class icingaweb2::module::monitoring(
     'resource' => 'icingaweb2-module-monitoring',
   }
 
-  $config_settings = {
+  $security_settings = {
     'protected_customvars' => $protected_customvars
   }
 
@@ -83,10 +83,10 @@ class icingaweb2::module::monitoring(
       'target'       => "${module_conf_dir}/backends.ini",
       'settings'     => delete_undef_values($backend_settings)
     },
-    'module-monitoring-config' => {
-      'section_name' => 'config',
-      'target'       => "${module_conf_dir}/config.ini",
-      'settings'     => delete_undef_values($config_settings)
+    'module-monitoring-security' => {
+      'section_name' => 'security',
+      'target'       => "${module_conf_dir}/security.ini",
+      'settings'     => delete_undef_values($security_settings)
     }
   }
 

--- a/manifests/module/monitoring.pp
+++ b/manifests/module/monitoring.pp
@@ -9,7 +9,7 @@
 #
 # [*pretected_customvars*]
 #   Custom variables in Icinga 2 may contain sensible information. Set patterns for custom variables that should be
-#   hidden in the web interface. Defaults to `*pw*, *pass*, community`
+#   hidden in the web interface. Defaults to `*pw*,*pass*,community`
 #
 # [*ido_type*]
 #   Type of your IDO database. Either `mysql` or `pgsql`. Defaults to `mysql`
@@ -34,7 +34,7 @@
 #
 class icingaweb2::module::monitoring(
   Enum['absent', 'present'] $ensure               = 'present',
-  String                    $protected_customvars = '*pw*, *pass*, community',
+  String                    $protected_customvars = '*pw*,*pass*,community',
   Enum['mysql', 'pgsql']    $ido_type             = 'mysql',
   Optional[String]          $ido_host             = undef,
   Integer[1,65535]          $ido_port             = 3306,

--- a/manifests/module/monitoring.pp
+++ b/manifests/module/monitoring.pp
@@ -33,15 +33,15 @@
 #   A hash of command transports.
 #
 class icingaweb2::module::monitoring(
-  Enum['absent', 'present'] $ensure               = 'present',
-  String                    $protected_customvars = '*pw*,*pass*,community',
-  Enum['mysql', 'pgsql']    $ido_type             = 'mysql',
-  Optional[String]          $ido_host             = undef,
-  Integer[1,65535]          $ido_port             = 3306,
-  Optional[String]          $ido_db_name          = undef,
-  Optional[String]          $ido_db_username      = undef,
-  Optional[String]          $ido_db_password      = undef,
-  Hash                      $commandtransports    = undef,
+  Enum['absent', 'present']      $ensure               = 'present',
+  Variant[String, Array[String]] $protected_customvars = '*pw*,*pass*,community',
+  Enum['mysql', 'pgsql']         $ido_type             = 'mysql',
+  Optional[String]               $ido_host             = undef,
+  Integer[1,65535]               $ido_port             = 3306,
+  Optional[String]               $ido_db_name          = undef,
+  Optional[String]               $ido_db_username      = undef,
+  Optional[String]               $ido_db_password      = undef,
+  Hash                           $commandtransports    = undef,
 ){
 
   $conf_dir        = $::icingaweb2::params::conf_dir
@@ -74,7 +74,10 @@ class icingaweb2::module::monitoring(
   }
 
   $security_settings = {
-    'protected_customvars' => $protected_customvars
+    'protected_customvars' => $protected_customvars ? {
+      String        => $protected_customvars,
+      Array[String] => join($protected_customvars, ','),
+    }
   }
 
   $settings = {

--- a/manifests/module/monitoring.pp
+++ b/manifests/module/monitoring.pp
@@ -7,7 +7,7 @@
 # [*ensure*]
 #   Enable or disable module. Defaults to `present`
 #
-# [*pretected_customvars*]
+# [*protected_customvars*]
 #   Custom variables in Icinga 2 may contain sensible information. Set patterns for custom variables that should be
 #   hidden in the web interface. Defaults to `*pw*,*pass*,community`
 #

--- a/spec/acceptance/icingaweb2_monitoring_spec.rb
+++ b/spec/acceptance/icingaweb2_monitoring_spec.rb
@@ -49,7 +49,7 @@ describe 'icingaweb2::module::monitoring class:' do
   describe file('/etc/icingaweb2/modules/monitoring/security.ini') do
     it { is_expected.to be_file }
     it { is_expected.to contain '[security]' }
-    it { is_expected.to contain 'protected_customvars = "*pw*, *pass*, community"' }
+    it { is_expected.to contain 'protected_customvars = "*pw*,*pass*,community"' }
   end
 
   describe file('/etc/icingaweb2/modules/monitoring/backends.ini') do

--- a/spec/acceptance/icingaweb2_monitoring_spec.rb
+++ b/spec/acceptance/icingaweb2_monitoring_spec.rb
@@ -46,9 +46,9 @@ describe 'icingaweb2::module::monitoring class:' do
     it { is_expected.to be_symlink }
   end
 
-  describe file('/etc/icingaweb2/modules/monitoring/config.ini') do
+  describe file('/etc/icingaweb2/modules/monitoring/security.ini') do
     it { is_expected.to be_file }
-    it { is_expected.to contain '[config]' }
+    it { is_expected.to contain '[security]' }
     it { is_expected.to contain 'protected_customvars = "*pw*, *pass*, community"' }
   end
 

--- a/spec/classes/monitoring_spec.rb
+++ b/spec/classes/monitoring_spec.rb
@@ -55,7 +55,7 @@ describe('icingaweb2::module::monitoring', :type => :class) do
                                  'section_name' => 'security',
                                  'target'=>'/etc/icingaweb2/modules/monitoring/security.ini',
                                  'settings'=>{
-                                     'protected_customvars'=>'*pw*, *pass*, community'
+                                     'protected_customvars'=>'*pw*,*pass*,community'
                                  }
                              }
                          }) }
@@ -106,7 +106,7 @@ describe('icingaweb2::module::monitoring', :type => :class) do
                                  'section_name' => 'security',
                                  'target'=>'/etc/icingaweb2/modules/monitoring/security.ini',
                                  'settings'=>{
-                                     'protected_customvars'=>'*pw*, *pass*, community'
+                                     'protected_customvars'=>'*pw*,*pass*,community'
                                  }
                              }
                          }) }

--- a/spec/classes/monitoring_spec.rb
+++ b/spec/classes/monitoring_spec.rb
@@ -51,9 +51,9 @@ describe('icingaweb2::module::monitoring', :type => :class) do
                                      'resource'=>'icingaweb2-module-monitoring'
                                  }
                              },
-                             'module-monitoring-config'=>{
-                                 'section_name' => 'config',
-                                 'target'=>'/etc/icingaweb2/modules/monitoring/config.ini',
+                             'module-monitoring-security'=>{
+                                 'section_name' => 'security',
+                                 'target'=>'/etc/icingaweb2/modules/monitoring/security.ini',
                                  'settings'=>{
                                      'protected_customvars'=>'*pw*, *pass*, community'
                                  }
@@ -102,9 +102,9 @@ describe('icingaweb2::module::monitoring', :type => :class) do
                                      'resource'=>'icingaweb2-module-monitoring'
                                  }
                              },
-                             'module-monitoring-config'=>{
-                                 'section_name' => 'config',
-                                 'target'=>'/etc/icingaweb2/modules/monitoring/config.ini',
+                             'module-monitoring-security'=>{
+                                 'section_name' => 'security',
+                                 'target'=>'/etc/icingaweb2/modules/monitoring/security.ini',
                                  'settings'=>{
                                      'protected_customvars'=>'*pw*, *pass*, community'
                                  }

--- a/spec/classes/monitoring_spec.rb
+++ b/spec/classes/monitoring_spec.rb
@@ -135,6 +135,39 @@ describe('icingaweb2::module::monitoring', :type => :class) do
 
         it { is_expected.to raise_error(Puppet::Error, /expects a match for Enum\['mysql', 'pgsql'\]/) }
       end
+
+      context "#{os} with array protected_customvars" do
+        let(:params) { {  :ido_type => 'mysql',
+                          :ido_host => 'localhost',
+                          :ido_db_name => 'icinga2',
+                          :ido_db_username => 'icinga2',
+                          :ido_db_password => 'icinga2',
+                          :commandtransports => {
+                           'foo' => {
+                             'transport' => 'local',
+                           }
+                         },
+                         :protected_customvars => ['foo', 'bar', '*baz*'] } }
+
+        it { is_expected.to contain_icingaweb2__module('monitoring')
+          .with_settings({
+                             'module-monitoring-backends'=>{
+                                 'section_name' => 'backends',
+                                 'target'=>'/etc/icingaweb2/modules/monitoring/backends.ini',
+                                 'settings'=>{
+                                     'type'=>'ido',
+                                     'resource'=>'icingaweb2-module-monitoring'
+                                 }
+                             },
+                             'module-monitoring-security'=>{
+                                 'section_name' => 'security',
+                                 'target'=>'/etc/icingaweb2/modules/monitoring/security.ini',
+                                 'settings'=>{
+                                     'protected_customvars'=>'foo,bar,*baz*'
+                                 }
+                             }
+                         }) }
+      end
     end
   end
 end


### PR DESCRIPTION
The current defaults for protected_customvars are completely broken. This patch series tries to fix them.

On top, another patch to make protected_customvars accept arrays of values instead of just strings, as that's what I expected when first using the module.

Tests updated to reflect changes.