### PR TITLE
Add missing curly bracket and trailing commas

### DIFF
--- a/README.md
+++ b/README.md
@@ -462,7 +462,8 @@ class { 'icingaweb2::module::generictts':
     'my-ticket-system' => {
       pattern => '/#([0-9]{4,6})/',
       url     => 'https://my.ticket.system/tickets/id=$1',
-    }
+    },
+  },
 }
 ```
 


### PR DESCRIPTION
The example in the README has a syntax error and puppet-lint doesn't like it too.  This commit fixes that.
See also https://github.com/Icinga/icingaweb2-module-generictts/pull/7