### PR TITLE
Rename default administrative user to 'icingaadmin'

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ generated.
 The module does not support the creation of databases, we encourage you to use either the [puppetlabs/mysql] or the
 [puppetlabs/puppetlabs-postgresql] module.
 
-:bulb: Default credentials are: **User:** `icinga` **Password**: `icinga`
+:bulb: Default credentials are: **User:** `icingaadmin` **Password**: `icinga`
 
 ##### MySQL
 Use MySQL as backend for user authentication in Icinga Web 2:

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -118,7 +118,7 @@ class icingaweb2::config {
     }
 
     icingaweb2::config::role { 'default admin user':
-      users       => 'icinga',
+      users       => 'icingaadmin',
       permissions => '*',
     }
 
@@ -131,7 +131,7 @@ class icingaweb2::config {
         }
 
         exec { 'create default user':
-          command     => "mysql -h '${db_host}' -u '${db_username}' -p'${db_password}' '${db_name}' -Ns -e 'INSERT INTO icingaweb_user (name, active, password_hash) VALUES (\"icinga\", 1, \"\$1\$3no6eqZp\$FlcHQDdnxGPqKadmfVcCU.\")'",
+          command     => "mysql -h '${db_host}' -u '${db_username}' -p'${db_password}' '${db_name}' -Ns -e 'INSERT INTO icingaweb_user (name, active, password_hash) VALUES (\"icingaadmin\", 1, \"\$1\$3no6eqZp\$FlcHQDdnxGPqKadmfVcCU.\")'",
           refreshonly => true,
         }
       }
@@ -145,7 +145,7 @@ class icingaweb2::config {
 
         exec { 'create default user':
           environment => ["PGPASSWORD=${db_password}"],
-          command     => "psql -h '${db_host}' -U '${db_username}' -d '${db_name}' -w -c \"INSERT INTO icingaweb_user(name, active, password_hash) VALUES ('icinga', 1, '\\\$1\\\$3no6eqZp\\\$FlcHQDdnxGPqKadmfVcCU.')\"",
+          command     => "psql -h '${db_host}' -U '${db_username}' -d '${db_name}' -w -c \"INSERT INTO icingaweb_user(name, active, password_hash) VALUES ('icingaadmin', 1, '\\\$1\\\$3no6eqZp\\\$FlcHQDdnxGPqKadmfVcCU.')\"",
           refreshonly => true,
         }
       }

--- a/spec/acceptance/icingaweb2_monitoring_spec.rb
+++ b/spec/acceptance/icingaweb2_monitoring_spec.rb
@@ -100,11 +100,11 @@ describe 'icingaweb2::module::monitoring class:' do
   describe file('/etc/icingaweb2/roles.ini') do
     it { is_expected.to be_file }
     it { is_expected.to contain '[default admin user]' }
-    it { is_expected.to contain 'users = "icinga"' }
+    it { is_expected.to contain 'users = "icingaadmin"' }
     it { is_expected.to contain 'permissions = "*"' }
   end
 
   describe command('mysql -e "select name from icingaweb2.icingaweb_user"') do
-    its(:stdout) { should match(%r{icinga}) }
+    its(:stdout) { should match(%r{icingaadmin}) }
   end
 end


### PR DESCRIPTION
This is the common default within the web setup wizard and
promoted anywhere else. Discussed with @bobapple already.

Tested inside the Icinga Vagrant boxes. Tests have been adopted too.