### PR TITLE
Provide specific port to mysql and postgresql

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -125,27 +125,27 @@ class icingaweb2::config {
     case $db_type {
       'mysql': {
         exec { 'import schema':
-          command => "mysql -h '${db_host}' -u '${db_username}' -p'${db_password}' '${db_name}' < '${schema_dir}/mysql.schema.sql'",
-          unless  => "mysql -h '${db_host}' -u '${db_username}' -p'${db_password}' '${db_name}' -Ns -e 'SELECT 1 FROM icingaweb_user'",
+          command => "mysql -h '${db_host}' -P '${db_port}' -u '${db_username}' -p'${db_password}' '${db_name}' < '${schema_dir}/mysql.schema.sql'",
+          unless  => "mysql -h '${db_host}' -P '${db_port}' -u '${db_username}' -p'${db_password}' '${db_name}' -Ns -e 'SELECT 1 FROM icingaweb_user'",
           notify  => Exec['create default user'],
         }
 
         exec { 'create default user':
-          command     => "mysql -h '${db_host}' -u '${db_username}' -p'${db_password}' '${db_name}' -Ns -e 'INSERT INTO icingaweb_user (name, active, password_hash) VALUES (\"icinga\", 1, \"\$1\$3no6eqZp\$FlcHQDdnxGPqKadmfVcCU.\")'",
+          command     => "mysql -h '${db_host}' -P '${db_port}' -u '${db_username}' -p'${db_password}' '${db_name}' -Ns -e 'INSERT INTO icingaweb_user (name, active, password_hash) VALUES (\"icinga\", 1, \"\$1\$3no6eqZp\$FlcHQDdnxGPqKadmfVcCU.\")'",
           refreshonly => true,
         }
       }
       'pgsql': {
         exec { 'import schema':
           environment => ["PGPASSWORD=${db_password}"],
-          command     => "psql -h '${db_host}' -U '${db_username}' -d '${db_name}' -w -f ${schema_dir}/pgsql.schema.sql",
-          unless      => "psql -h '${db_host}' -U '${db_username}' -d '${db_name}' -w -c 'SELECT 1 FROM icingaweb_user'",
+          command     => "psql -h '${db_host}' -p '${db_port}' -U '${db_username}' -d '${db_name}' -w -f ${schema_dir}/pgsql.schema.sql",
+          unless      => "psql -h '${db_host}' -p '${db_port}' -U '${db_username}' -d '${db_name}' -w -c 'SELECT 1 FROM icingaweb_user'",
           notify      => Exec['create default user'],
         }
 
         exec { 'create default user':
           environment => ["PGPASSWORD=${db_password}"],
-          command     => "psql -h '${db_host}' -U '${db_username}' -d '${db_name}' -w -c \"INSERT INTO icingaweb_user(name, active, password_hash) VALUES ('icinga', 1, '\\\$1\\\$3no6eqZp\\\$FlcHQDdnxGPqKadmfVcCU.')\"",
+          command     => "psql -h '${db_host}' -p '${db_port}' -U '${db_username}' -d '${db_name}' -w -c \"INSERT INTO icingaweb_user(name, active, password_hash) VALUES ('icinga', 1, '\\\$1\\\$3no6eqZp\\\$FlcHQDdnxGPqKadmfVcCU.')\"",
           refreshonly => true,
         }
       }


### PR DESCRIPTION
If a different port than the default was used on mysql or postgresql the puppet run failed because no port was specified in the command

This would solve [Setting up icingaweb2 with postgresql on a different port than 5432 leads to an error](https://github.com/Icinga/puppet-icingaweb2/issues/195)