### PR TITLE
Make sure module conf dir is created before inisettings are managed

### DIFF
--- a/manifests/module.pp
+++ b/manifests/module.pp
@@ -76,7 +76,11 @@ define icingaweb2::module(
     $ensure_module_config_dir = 'directory'
     $ensure_vcsrepo = 'present'
 
-    create_resources('icingaweb2::inisection', $settings)
+    create_resources('icingaweb2::inisection', $settings,
+      {
+        require => File["${conf_dir}/modules/${module}"]
+      }
+    )
   } else {
     $ensure_module_enabled = 'absent'
     $ensure_module_config_dir = 'absent'

--- a/manifests/module/generictts/ticketsystem.pp
+++ b/manifests/module/generictts/ticketsystem.pp
@@ -29,6 +29,7 @@ define icingaweb2::module::generictts::ticketsystem(
     settings     => {
       'pattern' => $pattern,
       'url'     => $url,
-    }
+    },
+    require      => Icingaweb2::Module['generictts'],
   }
 }

--- a/manifests/module/monitoring/commandtransport.pp
+++ b/manifests/module/monitoring/commandtransport.pp
@@ -64,5 +64,6 @@ define icingaweb2::module::monitoring::commandtransport(
     section_name => $commandtransport,
     target       => "${module_conf_dir}/commandtransports.ini",
     settings     => delete_undef_values($commandtransport_settings),
+    require      => Icingaweb2::Module['monitoring'],
   }
 }


### PR DESCRIPTION
The ordering between modules like `monitoring` and `generictts` was not defined, therefore it happened that puppet tried to manage (create) the initsettings files before the module config directory in `/etc/icingaweb2/modules/` was created. Example:
```
(vagrant--localdev)root@icinga-server:~# puppet agent -t
Info: Retrieving pluginfacts
Info: Retrieving plugin
Info: Loading facts
Info: Caching catalog for icinga-server.vagrant.dev
Info: Applying configuration version '1513718919'
Error: Could not set 'file' on ensure: No such file or directory @ dir_s_rmdir - /etc/icingaweb2/modules/monitoring/commandtransports.ini20171219-9410-10mdr15.lock
Error: Could not set 'file' on ensure: No such file or directory @ dir_s_rmdir - /etc/icingaweb2/modules/monitoring/commandtransports.ini20171219-9410-10mdr15.lock
Wrapped exception:
No such file or directory @ dir_s_rmdir - /etc/icingaweb2/modules/monitoring/commandtransports.ini20171219-9410-10mdr15.lock
Error: /Stage[main]/Icingaweb2::Module::Monitoring/Icingaweb2::Module::Monitoring::Commandtransport[icinga2]/Icingaweb2::Inisection[monitoring-commandtransport-icinga2]/Concat[/etc/icingaweb2/modules/monitoring/commandtransports.ini]/File[/etc/icingaweb2/modules/monitoring/commandtransports.ini]/ensure: change from absent to file failed: Could not set 'file' on ensure: No such file or directory @ dir_s_rmdir - /etc/icingaweb2/modules/monitoring/commandtransports.ini20171219-9410-10mdr15.lock
Error: Could not set 'file' on ensure: No such file or directory @ dir_s_rmdir - /etc/icingaweb2/modules/monitoring/backends.ini20171219-9410-dlrgt6.lock
Error: Could not set 'file' on ensure: No such file or directory @ dir_s_rmdir - /etc/icingaweb2/modules/monitoring/backends.ini20171219-9410-dlrgt6.lock
Wrapped exception:
No such file or directory @ dir_s_rmdir - /etc/icingaweb2/modules/monitoring/backends.ini20171219-9410-dlrgt6.lock
Error: /Stage[main]/Icingaweb2::Module::Monitoring/Icingaweb2::Module[monitoring]/Icingaweb2::Inisection[module-monitoring-backends]/Concat[/etc/icingaweb2/modules/monitoring/backends.ini]/File[/etc/icingaweb2/modules/monitoring/backends.ini]/ensure: change from absent to file failed: Could not set 'file' on ensure: No such file or directory @ dir_s_rmdir - /etc/icingaweb2/modules/monitoring/backends.ini20171219-9410-dlrgt6.lock
Error: Could not set 'file' on ensure: No such file or directory @ dir_s_rmdir - /etc/icingaweb2/modules/monitoring/config.ini20171219-9410-1qt4wem.lock
Error: Could not set 'file' on ensure: No such file or directory @ dir_s_rmdir - /etc/icingaweb2/modules/monitoring/config.ini20171219-9410-1qt4wem.lock
Wrapped exception:
No such file or directory @ dir_s_rmdir - /etc/icingaweb2/modules/monitoring/config.ini20171219-9410-1qt4wem.lock
Error: /Stage[main]/Icingaweb2::Module::Monitoring/Icingaweb2::Module[monitoring]/Icingaweb2::Inisection[module-monitoring-config]/Concat[/etc/icingaweb2/modules/monitoring/config.ini]/File[/etc/icingaweb2/modules/monitoring/config.ini]/ensure: change from absent to file failed: Could not set 'file' on ensure: No such file or directory @ dir_s_rmdir - /etc/icingaweb2/modules/monitoring/config.ini20171219-9410-1qt4wem.lock
Notice: /Stage[main]/Icingaweb2::Module::Monitoring/Icingaweb2::Module[monitoring]/File[/etc/icingaweb2/modules/monitoring]/ensure: created
Notice: Finished catalog run in 5.90 seconds
```

can be reproduced by running `rm -rf /etc/icingaweb2/modules/monitoring /etc/icingaweb2/modules/generictts; puppet agent -t`