### PR TITLE
set prio to 98 to outrule default repos

### DIFF
--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -88,6 +88,7 @@ class icingaweb2::repo {
               baseurl  => "http://packages.icinga.com/SUSE/${::facts['os']['release']['full']}/release/",
               enabled  => 1,
               gpgcheck => 1,
+              priority => 98,
               require  => Exec['import icinga gpg key']
             }
           }


### PR DESCRIPTION
* set repository priority to 98 to outrule default repositories and really use the icinga repos.