### PR TITLE
Refactor repo.pp

### DIFF
--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -68,27 +68,13 @@ class icingaweb2::repo {
         contain ::apt::update
       }
       'suse': {
-
-        file { '/etc/pki/GPG-KEY-icinga':
-          ensure => present,
-          source => 'http://packages.icinga.com/icinga.key',
-        }
-
-        exec { 'import icinga gpg key':
-          path      => '/bin:/usr/bin:/sbin:/usr/sbin',
-          command   => 'rpm --import /etc/pki/GPG-KEY-icinga',
-          unless    => "rpm -q gpg-pubkey-`echo $(gpg --throw-keyids < /etc/pki/GPG-KEY-icinga) | cut --characters=11-18 | tr [A-Z] [a-z]`",
-          require   => File['/etc/pki/GPG-KEY-icinga'],
-          logoutput => 'on_failure',
-        }
-
         case $::facts['os']['name'] {
           'SLES': {
             zypprepo { 'icinga-stable-release':
               baseurl  => "http://packages.icinga.com/SUSE/${::facts['os']['release']['full']}/release/",
               enabled  => 1,
               gpgcheck => 1,
-              require  => Exec['import icinga gpg key']
+              gpgkey   => 'http://packages.icinga.com/icinga.key',
             }
           }
           default: {


### PR DESCRIPTION
It is not necessary to import the GPG key in this way, because the type ```zypprepo``` already supports the parameter ```gpgkey```. 
https://github.com/voxpupuli/puppet-zypprepo/blob/master/lib/puppet/type/zypprepo.rb#L247-L253