### PR TITLE
Docs: icingaweb2::config::resource 'port' requires an integer, not a string

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ icingaweb2::config::resource{'my-sql':
   type        => 'db',
   db_type     => 'mysql',
   host        => 'localhost',
-  port        => '3306',
+  port        => 3306,
   db_name     => 'icingaweb2',
   db_username => 'root',
   db_password => 'supersecret',

--- a/examples/resource.pp
+++ b/examples/resource.pp
@@ -6,7 +6,7 @@ icingaweb2::config::resource{'my-sql':
   type        => 'db',
   db_type     => 'mysql',
   host        => 'localhost',
-  port        => '3306',
+  port        => 3306,
   db_name     => 'icingaweb2',
   db_username => 'root',
   db_password => 'supersecret',


### PR DESCRIPTION
Got that while implementing a custom resource for reporting while following the docs.