### PR TITLE
Add parameter poold_purge to class phpfpm

### DIFF
--- a/examples/nginx.pp
+++ b/examples/nginx.pp
@@ -50,7 +50,9 @@ nginx::resource::location { 'icingaweb':
   ssl_only       => true,
 }
 
-include ::phpfpm
+class { 'phpfpm':
+  poold_purge => true,
+}
 
 phpfpm::pool { 'main': }
 


### PR DESCRIPTION
We should purge configs which are not manage by Puppet, since the package php-fpm at Centos 7 provides a config for pool www by default.