### PR TITLE
Add info of needed git package to docs

### DIFF
--- a/manifests/module.pp
+++ b/manifests/module.pp
@@ -96,6 +96,10 @@ define icingaweb2::module(
 
   case $install_method {
     'git': {
+      package { 'git':
+        ensure => $ensure,
+      }
+      
       vcsrepo { $module_dir:
         ensure   => $ensure_vcsrepo,
         provider => 'git',


### PR DESCRIPTION
The module vcsrepo does not handle the installation of git. 

Maybe we could implement an additional parameter to provide the correct package name. Do I need to add an unit or acceptance test, too?