### PR TITLE
Add timeout to ldap resource

### DIFF
--- a/manifests/config/resource.pp
+++ b/manifests/config/resource.pp
@@ -45,6 +45,9 @@
 # [*ldap_encryption*]
 #   Type of encryption to use: none (default), starttls, ldaps. Only valid if `type` is `ldap`.
 #
+# [*ldap_timeout*]
+#   Timeout for the ldap connection, defaults to 5.
+#
 # === Examples
 #
 # Create a 'db' resource:
@@ -74,6 +77,7 @@ define icingaweb2::config::resource(
   Optional[String]                            $ldap_bind_dn    = undef,
   Optional[String]                            $ldap_bind_pw    = undef,
   Optional[Enum['none', 'starttls', 'ldaps']] $ldap_encryption = 'none',
+  Optional[Integer]                           $ldap_timeout    = 5,
 ) {
 
   $conf_dir = $::icingaweb2::params::conf_dir
@@ -100,6 +104,7 @@ define icingaweb2::config::resource(
         'bind_dn'    => $ldap_bind_dn,
         'bind_pw'    => $ldap_bind_pw,
         'encryption' => $ldap_encryption,
+        'timeout'    => $ldap_timeout,
       }
     }
     default: {

--- a/spec/defines/resource_spec.rb
+++ b/spec/defines/resource_spec.rb
@@ -39,8 +39,22 @@ describe('icingaweb2::config::resource', :type => :define) do
 
         it { is_expected.to contain_icingaweb2__inisection('resource-myresource')
           .with_target('/etc/icingaweb2/resources.ini')
-          .with_settings({'type'=>'ldap', 'hostname'=>'localhost', 'port'=>'389', 'root_dn'=>'cn=foo,dc=bar', 'bind_dn'=>'cn=root,dc=bar', 'bind_pw'=>'secret', 'encryption'=>'none'})}
+          .with_settings({'type'=>'ldap', 'hostname'=>'localhost', 'port'=>'389', 'root_dn'=>'cn=foo,dc=bar', 'bind_dn'=>'cn=root,dc=bar', 'bind_pw'=>'secret', 'encryption'=>'none', 'timeout' => '5'})}
+      end
 
+      context "#{os} with type ldap and changed ldap timeout" do
+        let(:params) { {
+            :type => 'ldap',
+            :host => 'localhost',
+            :port => 389,
+            :ldap_root_dn => 'cn=foo,dc=bar',
+            :ldap_bind_dn => 'cn=root,dc=bar',
+            :ldap_bind_pw => 'secret',
+            :ldap_timeout => 60 } }
+
+        it { is_expected.to contain_icingaweb2__inisection('resource-myresource')
+                                .with_target('/etc/icingaweb2/resources.ini')
+                                .with_settings({'type'=>'ldap', 'hostname'=>'localhost', 'port'=>'389', 'root_dn'=>'cn=foo,dc=bar', 'bind_dn'=>'cn=root,dc=bar', 'bind_pw'=>'secret', 'encryption'=>'none', 'timeout' => '60'})}
       end
 
       context "#{os} with invalid type" do


### PR DESCRIPTION
My current customer uses a big ldap setup with currently a few thousand nested groups. Depending on the workload of the chosen LDAP server, the response time may be too slow (and sadly, the additional servers are not queried in that case).

Icingaweb allows for setting a "timeout" variable for the ldap connection, which defaults to 5 (see [https://icinga.com/docs/icingaweb2/latest/doc/04-Resources/](https://icinga.com/docs/icingaweb2/latest/doc/04-Resources/)). This PR allows setting the timeout via this module.