### PR TITLE
Ensure config directory mode is set with setgid

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -122,11 +122,13 @@ class icingaweb2::config {
   }
 
   file { "${conf_dir}/modules":
-    ensure => 'directory'
+    ensure => 'directory',
+    mode   => '2770',
   }
 
   file { "${conf_dir}/enabledModules":
-    ensure => 'directory'
+    ensure => 'directory',
+    mode   => '2770',
   }
 
   if $import_schema or $config_backend == 'db' {

--- a/manifests/module.pp
+++ b/manifests/module.pp
@@ -90,6 +90,7 @@ define icingaweb2::module(
 
   file {"${conf_dir}/modules/${module}":
     ensure  => $ensure_module_config_dir,
+    mode    => '2770',
     force   => true,
     recurse => true,
   }


### PR DESCRIPTION
If this is not properly configured, files or directories created via the
web ui will have the web runtimes group as owner.