### PR TITLE
Check out repository as user

### DIFF
--- a/manifests/module.pp
+++ b/manifests/module.pp
@@ -96,6 +96,7 @@ define icingaweb2::module(
         provider => 'git',
         source   => $git_repository,
         revision => $git_revision,
+        user     => $conf_user,
       }
     }
     'none': { }


### PR DESCRIPTION
This way all checked out files belong to the user and not root.

Signed-off-by: Henry Pauli <henry@mixict.nl>