### PR TITLE
Update dependency requirement to minimum version

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ This module depends on
 
 * [icinga/ciinga] >= 1.0.0
     * needed if `manage_repos` is set to `true`
-* [puppetlabs/stdlib] >= 4.16.0
+* [puppetlabs/stdlib] >= 4.25.0
 * [puppetlabs/vcsrepo] >= 1.3.0
 * [puppetlabs/concat] >= 2.0.1
 

--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.16.0 < 8.0.0"
+      "version_requirement": ">= 4.25.0 < 8.0.0"
     },
     {
       "name": "puppetlabs/concat",


### PR DESCRIPTION
This module relies on stdlib::host which was only implemented in
puppetlabs-stdlib 4.25.0 and not 4.16.0

https://forge.puppet.com/modules/puppetlabs/stdlib/4.25.0#stdlibhost
https://forge.puppet.com/modules/puppetlabs/stdlib/4.16.0