### PR TITLE
Add parameter AddCGIPassAuth to Apache config

### DIFF
--- a/files/examples/apache2/for-mod_proxy_fcgi.conf
+++ b/files/examples/apache2/for-mod_proxy_fcgi.conf
@@ -37,10 +37,11 @@ Alias /icingaweb2 "/usr/share/icingaweb2/public"
         DirectoryIndex error_norewrite.html
         ErrorDocument 404 /icingaweb2/error_norewrite.html
     </IfModule>
-    
+
     # forwarding PHP requests to FPM
     # remove comments if you want to use FPM
     <FilesMatch "\.php$">
+        CGIPassAuth on
         SetHandler "proxy:fcgi://127.0.0.1:9000"
         ErrorDocument 503 /icingaweb2/error_unavailable.html
     </FilesMatch>


### PR DESCRIPTION
If PHP FPM is used for Icingaweb2, mod_proxy_fcgi on Debian will, by
default, strip Authentication Headers from the request.
While this does not influence the "normal" interaction with the website,
it will prohibit using the API functionality in an automated fashion (,
where Basic Authentication is used instead of cookies).