### PR TITLE
Fix compatibility for db schema imports in Icinga Web 2 2.11.4

### DIFF
--- a/data/Debian.yaml
+++ b/data/Debian.yaml
@@ -1,4 +1,5 @@
 ---
 icingaweb2::conf_user: www-data
+icingaweb2::globals::comp_db_schema_dir: /usr/share/icingaweb2/etc
 icingaweb2::globals::mysql_db_schema: /usr/share/icingaweb2/etc/schema/mysql.schema.sql
 icingaweb2::globals::pgsql_db_schema: /usr/share/icingaweb2/etc/schema/pgsql.schema.sql

--- a/data/FreeBSD.yaml
+++ b/data/FreeBSD.yaml
@@ -1,6 +1,8 @@
 ---
 icingaweb2::globals::package_name: icingaweb2-php74
 icingaweb2::globals::conf_dir: /usr/local/etc/icingaweb2
+icingaweb2::globals::data_dir: /usr/local/www/icingaweb2
+icingaweb2::globals::comp_db_schema_dir: /usr/local/www/icingaweb2/etc
 icingaweb2::globals::mysql_db_schema: /usr/local/www/icingaweb2/etc/schema/mysql.schema.sql
 icingaweb2::globals::pgsql_db_schema: /usr/local/www/icingaweb2/etc/schema/pgsql.schema.sql
 icingaweb2::globals::gettext_package_name: gettext-runtime

--- a/data/Linux-kernel.yaml
+++ b/data/Linux-kernel.yaml
@@ -1,6 +1,8 @@
 ---
 icingaweb2::globals::package_name: icingaweb2
 icingaweb2::globals::conf_dir: /etc/icingaweb2
+icingaweb2::globals::data_dir: /usr/share/icingaweb2
+icingaweb2::globals::comp_db_schema_dir: /usr/share/doc/icingaweb2
 icingaweb2::globals::mysql_db_schema: /usr/share/doc/icingaweb2/schema/mysql.schema.sql
 icingaweb2::globals::pgsql_db_schema: /usr/share/doc/icingaweb2/schema/pgsql.schema.sql
 icingaweb2::globals::mysql_vspheredb_schema: /usr/share/icingaweb2/modules/vspheredb/schema/mysql.sql

--- a/manifests/globals.pp
+++ b/manifests/globals.pp
@@ -8,6 +8,12 @@
 # @param conf_dir
 #   Path to the config files.
 #
+# @param data_dir
+#   Location of PHP data files.
+#
+# @param comp_db_schema_dir
+#   For compatibility, since in Icinga Web 2 2.11.4 the schema files have been moved.
+#
 # @param default_module_path
 #   Location of the modules.
 #
@@ -50,6 +56,8 @@
 class icingaweb2::globals (
   String                 $package_name,
   Stdlib::Absolutepath   $conf_dir,
+  Stdlib::Absolutepath   $data_dir,
+  Stdlib::Absolutepath   $comp_db_schema_dir,
   Stdlib::Absolutepath   $default_module_path,
   Stdlib::Absolutepath   $mysql_db_schema,
   Stdlib::Absolutepath   $pgsql_db_schema,

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -12,6 +12,8 @@ class icingaweb2::install {
   $extra_packages = $icingaweb2::extra_packages
   $conf_user      = $icingaweb2::conf_user
   $conf_group     = $icingaweb2::conf_group
+  $data_dir       = $icingaweb2::globals::data_dir
+  $comp_dir       = $icingaweb2::globals::comp_db_schema_dir
 
   File {
     mode    => '0660',
@@ -32,5 +34,18 @@ class icingaweb2::install {
   file { prefix(['navigation', 'preferences', 'dashboards'], "${conf_dir}/"):
     ensure => directory,
     mode   => '2770',
+  }
+
+  file { $comp_dir:
+    ensure => directory,
+    owner  => 'root',
+    group  => 'root',
+    mode   => '0755',
+  }
+
+  exec { 'link old db schema directory for compatibility':
+    path    => $facts['path'],
+    command => "ln -s ${data_dir}/schema ${comp_dir}/schema",
+    unless  => "stat ${comp_dir}/schema",
   }
 }


### PR DESCRIPTION
Location of database schema files have been moved, see https://github.com/Icinga/icingaweb2/pull/4964.