### PR TITLE
Remove management of package icingaweb2-module-monitoring on Debian/Ubuntu

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -2489,7 +2489,6 @@ The following parameters are available in the `icingaweb2::module::monitoring` c
 
 * [`ensure`](#-icingaweb2--module--monitoring--ensure)
 * [`protected_customvars`](#-icingaweb2--module--monitoring--protected_customvars)
-* [`manage_package`](#-icingaweb2--module--monitoring--manage_package)
 * [`ido_type`](#-icingaweb2--module--monitoring--ido_type)
 * [`ido_host`](#-icingaweb2--module--monitoring--ido_host)
 * [`ido_port`](#-icingaweb2--module--monitoring--ido_port)
@@ -2525,16 +2524,6 @@ Custom variables in Icinga 2 may contain sensible information. Set patterns for 
 that should be hidden in the web interface.
 
 Default value: `['*pw*', '*pass*', 'community']`
-
-##### <a name="-icingaweb2--module--monitoring--manage_package"></a>`manage_package`
-
-Data type: `Boolean`
-
-Set to `false` as Fix for Icinga Web >= 2.12.0 to do not manage the removed package
-`icingaweb2-module-monitoring` (only Debian/Ubuntu).
-See issue #368 (https://github.com/Icinga/puppet-icingaweb2/issues/368).
-
-Default value: `true`
 
 ##### <a name="-icingaweb2--module--monitoring--ido_type"></a>`ido_type`
 

--- a/manifests/module/monitoring.pp
+++ b/manifests/module/monitoring.pp
@@ -10,11 +10,6 @@
 #   Custom variables in Icinga 2 may contain sensible information. Set patterns for custom variables
 #   that should be hidden in the web interface.
 #
-# @param manage_package
-#   Set to `false` as Fix for Icinga Web >= 2.12.0 to do not manage the removed package
-#   `icingaweb2-module-monitoring` (only Debian/Ubuntu).
-#   See issue #368 (https://github.com/Icinga/puppet-icingaweb2/issues/368).
-#
 # @param ido_type
 #   Type of your IDO database. Either `mysql` or `pgsql`.
 #
@@ -96,7 +91,6 @@ class icingaweb2::module::monitoring (
   Enum['absent', 'present']      $ensure               = 'present',
   Variant[String, Array[String]] $protected_customvars = ['*pw*', '*pass*', 'community'],
   Enum['mysql', 'pgsql']         $ido_type             = 'mysql',
-  Boolean                        $manage_package       = true,
   Optional[Stdlib::Host]         $ido_host             = undef,
   Optional[Stdlib::Port]         $ido_port             = undef,
   Optional[String]               $ido_db_name          = undef,
@@ -119,22 +113,6 @@ class icingaweb2::module::monitoring (
 
   $conf_dir        = $icingaweb2::globals::conf_dir
   $module_conf_dir = "${conf_dir}/modules/monitoring"
-
-  case $facts['os']['family'] {
-    'Debian': {
-      if $manage_package {
-        $install_method = 'package'
-        $package_name   = 'icingaweb2-module-monitoring'
-      } else {
-        $install_method = 'none'
-        $package_name   = undef
-      }
-    }
-    default: {
-      $install_method = 'none'
-      $package_name   = undef
-    }
-  }
 
   $tls = delete($icingaweb2::config::tls, ['key', 'cert', 'cacert']) + delete_undef_values(icingaweb2::cert::files(
       'client',
@@ -201,8 +179,7 @@ class icingaweb2::module::monitoring (
 
   icingaweb2::module { 'monitoring':
     ensure         => $ensure,
-    install_method => $install_method,
-    package_name   => $package_name,
+    install_method => 'none',
     settings       => $settings,
   }
 }

--- a/spec/classes/doc_spec.rb
+++ b/spec/classes/doc_spec.rb
@@ -13,7 +13,7 @@ describe('icingaweb2::module::doc', type: :class) do
         facts
       end
 
-      case facts[:osfamily]
+      case facts[:os]['family']
       when 'Debian'
         let(:install_method) { 'package' }
         let(:package_name) { 'icingaweb2-module-doc' }
@@ -33,7 +33,7 @@ describe('icingaweb2::module::doc', type: :class) do
             .with_ensure('present')
         }
 
-        if facts[:osfamily] == 'Debian'
+        if facts[:os]['family'] == 'Debian'
           it { is_expected.to contain_package('icingaweb2-module-doc').with('ensure' => 'installed') }
         end
       end
@@ -49,7 +49,7 @@ describe('icingaweb2::module::doc', type: :class) do
             .with_ensure('absent')
         }
 
-        if facts[:osfamily] == 'Debian'
+        if facts[:os]['family'] == 'Debian'
           it { is_expected.to contain_package('icingaweb2-module-doc').with('ensure' => 'installed') }
         end
       end

--- a/spec/classes/monitoring_spec.rb
+++ b/spec/classes/monitoring_spec.rb
@@ -13,15 +13,6 @@ describe('icingaweb2::module::monitoring', type: :class) do
         facts
       end
 
-      case facts[:osfamily]
-      when 'Debian'
-        let(:install_method) { 'package' }
-        let(:package_name) { 'icingaweb2-module-monitoring' }
-      else
-        let(:install_method) { 'none' }
-        let(:package_name) { nil }
-      end
-
       context "#{os} with ido_type 'mysql' and commandtransport 'api'" do
         let(:params) do
           { ido_type: 'mysql',
@@ -39,8 +30,7 @@ describe('icingaweb2::module::monitoring', type: :class) do
 
         it {
           is_expected.to contain_icingaweb2__module('monitoring')
-            .with_install_method(install_method)
-            .with_package_name(package_name)
+            .with_install_method('none')
             .with_module_dir('/usr/share/icingaweb2/modules/monitoring')
             .with_settings('module-monitoring-backends' => {
                              'section_name' => 'backends',
@@ -93,8 +83,7 @@ describe('icingaweb2::module::monitoring', type: :class) do
 
         it do
           is_expected.to contain_icingaweb2__module('monitoring')
-            .with_install_method(install_method)
-            .with_package_name(package_name)
+            .with_install_method('none')
             .with_module_dir('/usr/share/icingaweb2/modules/monitoring')
             .with_settings('module-monitoring-backends' => {
                              'section_name' => 'backends',
@@ -123,30 +112,9 @@ describe('icingaweb2::module::monitoring', type: :class) do
             .with_password('icinga2')
         }
 
-        if facts[:osfamily] == 'Debian'
-          it { is_expected.to contain_package('icingaweb2-module-monitoring').with('ensure' => 'installed') }
-        end
-
         it {
           is_expected.to contain_icingaweb2__module__monitoring__commandtransport('foo')
             .with_transport('local')
-        }
-      end
-
-      context "#{os} with manage_package 'false'" do
-        let(:params) do
-          { ido_type: 'mysql',
-            ido_host: 'localhost',
-            ido_db_name: 'icinga2',
-            ido_db_username: 'icinga2',
-            ido_db_password: 'icinga2',
-            manage_package: false }
-        end
-
-        it {
-          is_expected.to contain_icingaweb2__module('monitoring')
-            .with_install_method('none')
-            .with_module_dir('/usr/share/icingaweb2/modules/monitoring')
         }
       end
 

--- a/spec/classes/translation_spec.rb
+++ b/spec/classes/translation_spec.rb
@@ -32,7 +32,7 @@ describe('icingaweb2::module::translation', type: :class) do
                            })
         }
 
-        case facts[:osfamily]
+        case facts[:os]['family']
         when 'Debian', 'RedHat'
           it { is_expected.to contain_package('gettext').with('ensure' => 'present') }
         when 'Suse'
@@ -50,7 +50,7 @@ describe('icingaweb2::module::translation', type: :class) do
             .with_module_dir('/usr/share/icingaweb2/modules/translation')
         }
 
-        case facts[:osfamily]
+        case facts[:os]['family']
         when 'Debian', 'RedHat'
           it { is_expected.to contain_package('gettext').with('ensure' => 'absent') }
         when 'Suse'


### PR DESCRIPTION
If you're still using an icingaweb2 version that requires this package and also has no dependency on icingaweb2-module-monitoring, simply add the package to the extra_packages parameter of the icingaweb2 class. 