### PR TITLE
Fix icingadb::db_password to be an optional parameter

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -1927,9 +1927,11 @@ Default value: `'icingadb'`
 
 ##### <a name="-icingaweb2--module--icingadb--db_password"></a>`db_password`
 
-Data type: `Icingaweb2::Secret`
+Data type: `Optional[Icingaweb2::Secret]`
 
 Password for IcingaDB database connection.
+
+Default value: `undef`
 
 ##### <a name="-icingaweb2--module--icingadb--db_charset"></a>`db_charset`
 

--- a/manifests/module/icingadb.pp
+++ b/manifests/module/icingadb.pp
@@ -118,12 +118,12 @@
 class icingaweb2::module::icingadb (
   String                          $package_name,
   Enum['mysql', 'pgsql']          $db_type,
-  Icingaweb2::Secret              $db_password,
   Enum['absent', 'present']       $ensure                   = 'present',
   Stdlib::Host                    $db_host                  = 'localhost',
   Optional[Stdlib::Port]          $db_port                  = undef,
   String                          $db_name                  = 'icingadb',
   String                          $db_username              = 'icingadb',
+  Optional[Icingaweb2::Secret]    $db_password              = undef,
   Optional[String]                $db_charset               = undef,
   Optional[Boolean]               $db_use_tls               = undef,
   Optional[String]                $db_tls_cert              = undef,

--- a/spec/classes/icingadb_spec.rb
+++ b/spec/classes/icingadb_spec.rb
@@ -17,7 +17,6 @@ describe('icingaweb2::module::icingadb', type: :class) do
         let(:params) do
           {
             db_type: 'mysql',
-            db_password: 'foobar',
           }
         end
 
@@ -64,7 +63,6 @@ describe('icingaweb2::module::icingadb', type: :class) do
               'port' => 3306,
               'database' => 'icingadb',
               'username' => 'icingadb',
-              'password' => 'foobar',
               'charset'  => nil,
               'use_tls'  => nil,
             },
@@ -76,7 +74,6 @@ describe('icingaweb2::module::icingadb', type: :class) do
         let(:params) do
           {
             db_type: 'pgsql',
-            db_password: 'foobar',
           }
         end
 
@@ -123,7 +120,6 @@ describe('icingaweb2::module::icingadb', type: :class) do
               'port' => 5432,
               'database' => 'icingadb',
               'username' => 'icingadb',
-              'password' => 'foobar',
               'charset'  => nil,
               'use_tls'  => nil,
             },


### PR DESCRIPTION
Therefore it is now also possible to configure a tis client cert based authentication without setting a password.