### PR TITLE
Add parameter to name the database resources

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -203,6 +203,7 @@ The following parameters are available in the `icingaweb2` class:
 * [`extra_packages`](#-icingaweb2--extra_packages)
 * [`import_schema`](#-icingaweb2--import_schema)
 * [`db_type`](#-icingaweb2--db_type)
+* [`db_resource_name`](#-icingaweb2--db_resource_name)
 * [`db_host`](#-icingaweb2--db_host)
 * [`db_port`](#-icingaweb2--db_port)
 * [`db_name`](#-icingaweb2--db_name)
@@ -325,6 +326,12 @@ whereas with mysql its different options.
 Data type: `Enum['mysql', 'pgsql']`
 
 Database type, can be either `mysql` or `pgsql`.
+
+##### <a name="-icingaweb2--db_resource_name"></a>`db_resource_name`
+
+Data type: `String`
+
+Name for the icingaweb2 database resource.
 
 ##### <a name="-icingaweb2--db_host"></a>`db_host`
 
@@ -963,6 +970,7 @@ The following parameters are available in the `icingaweb2::module::director` cla
 * [`install_method`](#-icingaweb2--module--director--install_method)
 * [`package_name`](#-icingaweb2--module--director--package_name)
 * [`db_type`](#-icingaweb2--module--director--db_type)
+* [`db_resource_name`](#-icingaweb2--module--director--db_resource_name)
 * [`db_host`](#-icingaweb2--module--director--db_host)
 * [`db_port`](#-icingaweb2--module--director--db_port)
 * [`db_name`](#-icingaweb2--module--director--db_name)
@@ -1036,6 +1044,12 @@ Package name of the module. This setting is only valid in combination with the i
 Data type: `Enum['mysql', 'pgsql']`
 
 Type of your database. Either `mysql` or `pgsql`.
+
+##### <a name="-icingaweb2--module--director--db_resource_name"></a>`db_resource_name`
+
+Data type: `String`
+
+Name for the director database resource.
 
 ##### <a name="-icingaweb2--module--director--db_host"></a>`db_host`
 
@@ -1694,6 +1708,7 @@ The following parameters are available in the `icingaweb2::module::icingadb` cla
 * [`ensure`](#-icingaweb2--module--icingadb--ensure)
 * [`package_name`](#-icingaweb2--module--icingadb--package_name)
 * [`db_type`](#-icingaweb2--module--icingadb--db_type)
+* [`db_resource_name`](#-icingaweb2--module--icingadb--db_resource_name)
 * [`db_host`](#-icingaweb2--module--icingadb--db_host)
 * [`db_port`](#-icingaweb2--module--icingadb--db_port)
 * [`db_name`](#-icingaweb2--module--icingadb--db_name)
@@ -1745,6 +1760,12 @@ IicngaDB-Web module package name.
 Data type: `Enum['mysql', 'pgsql']`
 
 Type of your IDO database. Either `mysql` or `pgsql`.
+
+##### <a name="-icingaweb2--module--icingadb--db_resource_name"></a>`db_resource_name`
+
+Data type: `String`
+
+Name for the icingadb database resource.
 
 ##### <a name="-icingaweb2--module--icingadb--db_host"></a>`db_host`
 
@@ -2120,6 +2141,7 @@ The following parameters are available in the `icingaweb2::module::monitoring` c
 * [`ido_type`](#-icingaweb2--module--monitoring--ido_type)
 * [`ido_host`](#-icingaweb2--module--monitoring--ido_host)
 * [`ido_port`](#-icingaweb2--module--monitoring--ido_port)
+* [`ido_resource_name`](#-icingaweb2--module--monitoring--ido_resource_name)
 * [`ido_db_name`](#-icingaweb2--module--monitoring--ido_db_name)
 * [`ido_db_username`](#-icingaweb2--module--monitoring--ido_db_username)
 * [`ido_db_password`](#-icingaweb2--module--monitoring--ido_db_password)
@@ -2168,6 +2190,12 @@ Data type: `Optional[Stdlib::Port]`
 Port of the IDO database.
 
 Default value: `undef`
+
+##### <a name="-icingaweb2--module--monitoring--ido_resource_name"></a>`ido_resource_name`
+
+Data type: `String`
+
+Resource name for the IDO database.
 
 ##### <a name="-icingaweb2--module--monitoring--ido_db_name"></a>`ido_db_name`
 
@@ -2532,6 +2560,7 @@ The following parameters are available in the `icingaweb2::module::reporting` cl
 * [`install_method`](#-icingaweb2--module--reporting--install_method)
 * [`package_name`](#-icingaweb2--module--reporting--package_name)
 * [`db_type`](#-icingaweb2--module--reporting--db_type)
+* [`db_resource_name`](#-icingaweb2--module--reporting--db_resource_name)
 * [`db_host`](#-icingaweb2--module--reporting--db_host)
 * [`db_port`](#-icingaweb2--module--reporting--db_port)
 * [`db_name`](#-icingaweb2--module--reporting--db_name)
@@ -2600,6 +2629,12 @@ Package name of the module. This setting is only valid in combination with the i
 Data type: `Enum['mysql', 'pgsql']`
 
 The database type. Either mysql or postgres.
+
+##### <a name="-icingaweb2--module--reporting--db_resource_name"></a>`db_resource_name`
+
+Data type: `String`
+
+Name for the reporting database resource.
 
 ##### <a name="-icingaweb2--module--reporting--db_host"></a>`db_host`
 
@@ -2811,6 +2846,7 @@ The following parameters are available in the `icingaweb2::module::vspheredb` cl
 * [`install_method`](#-icingaweb2--module--vspheredb--install_method)
 * [`package_name`](#-icingaweb2--module--vspheredb--package_name)
 * [`db_type`](#-icingaweb2--module--vspheredb--db_type)
+* [`db_resource_name`](#-icingaweb2--module--vspheredb--db_resource_name)
 * [`db_host`](#-icingaweb2--module--vspheredb--db_host)
 * [`db_port`](#-icingaweb2--module--vspheredb--db_port)
 * [`db_name`](#-icingaweb2--module--vspheredb--db_name)
@@ -2878,6 +2914,12 @@ Package name of the module. This setting is only valid in combination with the i
 Data type: `Enum['mysql']`
 
 The database type. Either mysql or postgres.
+
+##### <a name="-icingaweb2--module--vspheredb--db_resource_name"></a>`db_resource_name`
+
+Data type: `String`
+
+Name for the vspheredb database resource.
 
 ##### <a name="-icingaweb2--module--vspheredb--db_host"></a>`db_host`
 
@@ -3065,6 +3107,7 @@ The following parameters are available in the `icingaweb2::module::x509` class:
 * [`install_method`](#-icingaweb2--module--x509--install_method)
 * [`package_name`](#-icingaweb2--module--x509--package_name)
 * [`db_type`](#-icingaweb2--module--x509--db_type)
+* [`db_resource_name`](#-icingaweb2--module--x509--db_resource_name)
 * [`db_host`](#-icingaweb2--module--x509--db_host)
 * [`db_port`](#-icingaweb2--module--x509--db_port)
 * [`db_name`](#-icingaweb2--module--x509--db_name)
@@ -3132,6 +3175,12 @@ Package name of the module. This setting is only valid in combination with the i
 Data type: `Enum['mysql', 'pgsql']`
 
 The database type. Either mysql or pgsql.
+
+##### <a name="-icingaweb2--module--x509--db_resource_name"></a>`db_resource_name`
+
+Data type: `String`
+
+Name for the x509 database resource.
 
 ##### <a name="-icingaweb2--module--x509--db_host"></a>`db_host`
 

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -11,6 +11,7 @@ icingaweb2::theme_disabled: false
 icingaweb2::manage_repos: false
 icingaweb2::manage_package: true
 icingaweb2::import_schema: false
+icingaweb2::db_resource_name: icingaweb2
 icingaweb2::db_host: localhost
 icingaweb2::db_name: icingaweb2
 icingaweb2::db_username: icingaweb2
@@ -28,6 +29,7 @@ icingaweb2::module::monitoring::protected_customvars:
   - '*pass*'
   - 'community'
 icingaweb2::module::monitoring::ido_host: localhost
+icingaweb2::module::monitoring::ido_resource_name: icinga2
 icingaweb2::module::monitoring::ido_db_name: icinga2
 icingaweb2::module::monitoring::ido_db_username: icinga2
 icingaweb2::module::monitoring::commandtransports: {}
@@ -35,6 +37,7 @@ icingaweb2::module::monitoring::commandtransports: {}
 icingaweb2::module::icingadb::ensure: present
 icingaweb2::module::icingadb::commandtransports: {}
 icingaweb2::module::icingadb::redis_host: localhost
+icingaweb2::module::icingadb::db_resource_name: icingadb
 icingaweb2::module::icingadb::db_host: localhost
 icingaweb2::module::icingadb::db_name: icingadb
 icingaweb2::module::icingadb::db_username: icingadb
@@ -50,6 +53,7 @@ icingaweb2::module::director::manage_service: true
 icingaweb2::module::director::service_ensure: running
 icingaweb2::module::director::service_enable: true
 icingaweb2::module::director::service_user: icingadirector
+icingaweb2::module::director::db_resource_name: director
 icingaweb2::module::director::db_host: localhost
 icingaweb2::module::director::db_name: director
 icingaweb2::module::director::db_username: director
@@ -64,6 +68,7 @@ icingaweb2::module::reporting::service_ensure: running
 icingaweb2::module::reporting::service_enable: true
 icingaweb2::module::reporting::service_user: icingareporting
 icingaweb2::module::reporting::import_schema: false
+icingaweb2::module::reporting::db_resource_name: reporting
 icingaweb2::module::reporting::db_host: localhost
 icingaweb2::module::reporting::db_name: reporting
 icingaweb2::module::reporting::db_username: reporting
@@ -88,6 +93,7 @@ icingaweb2::module::x509::service_ensure: running
 icingaweb2::module::x509::service_enable: true
 icingaweb2::module::x509::service_user: icingax509
 icingaweb2::module::x509::import_schema: false
+icingaweb2::module::x509::db_resource_name: x509
 icingaweb2::module::x509::db_host: localhost
 icingaweb2::module::x509::db_name: x509
 icingaweb2::module::x509::db_username: x509
@@ -102,6 +108,7 @@ icingaweb2::module::vspheredb::service_ensure: running
 icingaweb2::module::vspheredb::service_enable: true
 icingaweb2::module::vspheredb::service_user: icingavspheredb
 icingaweb2::module::vspheredb::import_schema: false
+icingaweb2::module::vspheredb::db_resource_name: vspheredb
 icingaweb2::module::vspheredb::db_host: localhost
 icingaweb2::module::vspheredb::db_name: vspheredb
 icingaweb2::module::vspheredb::db_username: vspheredb

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -29,12 +29,12 @@ class icingaweb2::config {
   $mysql_schema         = $icingaweb2::globals::mysql_db_schema
   $pgsql_schema         = $icingaweb2::globals::pgsql_db_schema
   $db                   = $icingaweb2::db
+  $db_resource          = $icingaweb2::db_resource_name
 
   $default_domain       = $icingaweb2::default_domain
   $admin_role           = $icingaweb2::admin_role
   $admin_username       = $icingaweb2::default_admin_username
   $admin_password       = icingaweb2::unwrap($icingaweb2::default_admin_password)
-  $config_resource      = "${db['type']}-icingaweb2"
 
   $use_tls              = $icingaweb2::use_tls
   $tls                  = $icingaweb2::tls + {
@@ -64,7 +64,7 @@ class icingaweb2::config {
   $settings = {
     'show_stacktraces' => $show_stacktraces,
     'module_path'      => join(unique([$default_module_path] + $module_path), ':'),
-    'config_resource'  => $config_resource,
+    'config_resource'  => $db_resource,
   }
 
   icingaweb2::inisection { 'config-global':
@@ -133,7 +133,7 @@ class icingaweb2::config {
     }
   }
 
-  icingaweb2::resource::database { "${db['type']}-icingaweb2":
+  icingaweb2::resource::database { $db_resource:
     type         => $db['type'],
     host         => $db['host'],
     port         => $db['port'],
@@ -151,12 +151,12 @@ class icingaweb2::config {
 
   icingaweb2::config::groupbackend { "${db['type']}-group":
     backend  => 'db',
-    resource => "${db['type']}-icingaweb2",
+    resource => $db_resource,
   }
 
   icingaweb2::config::authmethod { "${db['type']}-auth":
     backend  => 'db',
-    resource => "${db['type']}-icingaweb2",
+    resource => $db_resource,
   }
 
   if $import_schema {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -47,6 +47,9 @@
 # @param db_type
 #   Database type, can be either `mysql` or `pgsql`.
 #
+# @param db_resource_name
+#   Name for the icingaweb2 database resource.
+#
 # @param db_host
 #   Database hostname.
 #
@@ -226,6 +229,7 @@ class icingaweb2 (
   Hash[String, Hash[String, Any]]                 $user_backends,
   Hash[String, Hash[String, Any]]                 $group_backends,
   Variant[Boolean, Enum['mariadb', 'mysql']]      $import_schema,
+  String                                          $db_resource_name,
   Stdlib::Host                                    $db_host,
   String                                          $db_name,
   String                                          $db_username,

--- a/manifests/module/director.pp
+++ b/manifests/module/director.pp
@@ -24,6 +24,9 @@
 # @param db_type
 #   Type of your database. Either `mysql` or `pgsql`.
 #
+# @param db_resource_name
+#   Name for the director database resource.
+#
 # @param db_host
 #   Hostname of the database.
 #
@@ -138,6 +141,7 @@ class icingaweb2::module::director (
   Boolean                        $import_schema,
   Boolean                        $kickstart,
   Enum['mysql', 'pgsql']         $db_type,
+  String                         $db_resource_name,
   Stdlib::Host                   $db_host,
   String                         $db_name,
   String                         $db_username,
@@ -190,7 +194,7 @@ class icingaweb2::module::director (
       'section_name' => 'db',
       'target'       => "${module_conf_dir}/config.ini",
       'settings'     => {
-        'resource'   => 'icingaweb2-module-director',
+        'resource'   => $db_resource_name,
       },
     },
   }

--- a/manifests/module/director/config.pp
+++ b/manifests/module/director/config.pp
@@ -10,6 +10,7 @@ class icingaweb2::module::director::config {
   $icingacli_bin  = $icingaweb2::globals::icingacli_bin
   $install_method = $icingaweb2::module::director::install_method
   $db             = $icingaweb2::module::director::db
+  $db_resource    = $icingaweb2::module::director::db_resource_name
   $import_schema  = $icingaweb2::module::director::import_schema
   $kickstart      = $icingaweb2::module::director::kickstart
   $use_tls        = $icingaweb2::module::director::use_tls
@@ -28,7 +29,7 @@ class icingaweb2::module::director::config {
     provider => 'shell',
   }
 
-  icingaweb2::resource::database { 'icingaweb2-module-director':
+  icingaweb2::resource::database { $db_resource:
     type         => $db['type'],
     host         => $db['host'],
     port         => $db['port'],

--- a/manifests/module/icingadb.pp
+++ b/manifests/module/icingadb.pp
@@ -12,6 +12,9 @@
 # @param db_type
 #   Type of your IDO database. Either `mysql` or `pgsql`.
 #
+# @param db_resource_name
+#   Name for the icingadb database resource.
+#
 # @param db_host
 #   Hostname of the IcingaDB database.
 #
@@ -120,8 +123,9 @@ class icingaweb2::module::icingadb (
   String                          $package_name,
   Stdlib::Host                    $redis_host,
   Hash[String, Hash]              $commandtransports,
-  Stdlib::Host                    $db_host,
   Enum['mysql', 'pgsql']          $db_type,
+  String                          $db_resource_name,
+  Stdlib::Host                    $db_host,
   String                          $db_name,
   String                          $db_username,
   Optional[Stdlib::Port]          $db_port                  = undef,
@@ -196,7 +200,7 @@ class icingaweb2::module::icingadb (
       'section_name' => 'icingadb',
       'target'       => "${module_conf_dir}/config.ini",
       'settings'     => {
-        resource => 'icingaweb2-module-icingadb',
+        resource => $db_resource_name,
       },
     },
     'icingaweb2-module-icingadb-redis' => {

--- a/manifests/module/icingadb/config.pp
+++ b/manifests/module/icingadb/config.pp
@@ -9,6 +9,7 @@ class icingaweb2::module::icingadb::config {
   $ensure            = $icingaweb2::module::icingadb::ensure
   $module_conf_dir   = "${icingaweb2::globals::conf_dir}/modules/icingadb"
   $db_type           = $icingaweb2::module::icingadb::db_type
+  $db_resource       = $icingaweb2::module::icingadb::db_resource_name
   $db_host           = $icingaweb2::module::icingadb::db_host
   $db_port           = $icingaweb2::module::icingadb::db_port
   $db_name           = $icingaweb2::module::icingadb::db_name
@@ -25,7 +26,7 @@ class icingaweb2::module::icingadb::config {
   $settings          = $icingaweb2::module::icingadb::settings
   $commandtransports = $icingaweb2::module::icingadb::commandtransports
 
-  icingaweb2::resource::database { 'icingaweb2-module-icingadb':
+  icingaweb2::resource::database { $db_resource:
     type         => $db_type,
     host         => $db_host,
     port         => $db_port,

--- a/manifests/module/monitoring.pp
+++ b/manifests/module/monitoring.pp
@@ -19,6 +19,9 @@
 # @param ido_port
 #   Port of the IDO database.
 #
+# @param ido_resource_name
+#   Resource name for the IDO database.
+#
 # @param ido_db_name
 #   Name of the IDO database.
 #
@@ -93,6 +96,7 @@ class icingaweb2::module::monitoring (
   Hash                           $commandtransports,
   Enum['mysql', 'pgsql']         $ido_type,
   Stdlib::Host                   $ido_host,
+  String                         $ido_resource_name,
   String                         $ido_db_name,
   String                         $ido_db_username,
   Optional[Stdlib::Port]         $ido_port             = undef,
@@ -136,7 +140,7 @@ class icingaweb2::module::monitoring (
 
   $backend_settings = {
     'type'     => 'ido',
-    'resource' => 'icingaweb2-module-monitoring',
+    'resource' => $ido_resource_name,
   }
 
   $security_settings = {

--- a/manifests/module/monitoring/config.pp
+++ b/manifests/module/monitoring/config.pp
@@ -9,6 +9,7 @@ class icingaweb2::module::monitoring::config {
   $settings          = $icingaweb2::module::monitoring::settings
   $db                = $icingaweb2::module::monitoring::db
   $db_charset        = $icingaweb2::module::monitoring::ido_db_charset
+  $db_resource       = $icingaweb2::module::monitoring::ido_resource_name
   $commandtransports = $icingaweb2::module::monitoring::commandtransports
   $use_tls           = $icingaweb2::module::monitoring::use_tls
   $tls               = $icingaweb2::module::monitoring::tls + {
@@ -18,7 +19,7 @@ class icingaweb2::module::monitoring::config {
     cipher      => icingaweb2::pick($icingaweb2::module::monitoring::tls_cipher, $icingaweb2::config::tls['cipher']),
   }
 
-  icingaweb2::resource::database { 'icingaweb2-module-monitoring':
+  icingaweb2::resource::database { $db_resource:
     type         => $db['type'],
     host         => $db['host'],
     port         => $db['port'],

--- a/manifests/module/reporting.pp
+++ b/manifests/module/reporting.pp
@@ -21,6 +21,9 @@
 # @param db_type
 #   The database type. Either mysql or postgres.
 #
+# @param db_resource_name
+#   Name for the reporting database resource.
+#
 # @param db_host
 #   The host where the reporting database will be running
 #
@@ -112,6 +115,7 @@ class icingaweb2::module::reporting (
   String                                     $service_user,
   Variant[Boolean, Enum['mariadb', 'mysql']] $import_schema,
   Enum['mysql', 'pgsql']                     $db_type,
+  String                                     $db_resource_name,
   Stdlib::Host                               $db_host,
   String                                     $db_name,
   String                                     $db_username,
@@ -162,7 +166,7 @@ class icingaweb2::module::reporting (
       'section_name' => 'backend',
       'target'       => "${module_conf_dir}/config.ini",
       'settings'     => {
-        'resource' => 'reporting',
+        'resource' => $db_resource_name,
       },
     },
     'icingaweb2-module-reporting-mail'    => {

--- a/manifests/module/reporting/config.pp
+++ b/manifests/module/reporting/config.pp
@@ -11,6 +11,7 @@ class icingaweb2::module::reporting::config {
   $mysql_schema    = "${icingaweb2::module::reporting::module_dir}${icingaweb2::globals::mysql_reporting_schema}"
   $pgsql_schema    = "${icingaweb2::module::reporting::module_dir}${icingaweb2::globals::pgsql_reporting_schema}"
   $db              = $icingaweb2::module::reporting::db
+  $db_resource     = $icingaweb2::module::reporting::db_resource_name
   $import_schema   = $icingaweb2::module::reporting::import_schema
   $use_tls         = $icingaweb2::module::reporting::use_tls
   $tls             = $icingaweb2::module::reporting::tls + {
@@ -47,7 +48,7 @@ class icingaweb2::module::reporting::config {
     }
   }
 
-  icingaweb2::resource::database { 'reporting':
+  icingaweb2::resource::database { $db_resource:
     type         => $db['type'],
     host         => $db['host'],
     port         => $db['port'],

--- a/manifests/module/vspheredb.pp
+++ b/manifests/module/vspheredb.pp
@@ -21,6 +21,9 @@
 # @param db_type
 #   The database type. Either mysql or postgres.
 #
+# @param db_resource_name
+#   Name for the vspheredb database resource.
+#
 # @param db_host
 #   The host where the vspheredb-database will be running
 #
@@ -109,6 +112,7 @@ class icingaweb2::module::vspheredb (
   String                                     $service_user,
   Variant[Boolean, Enum['mariadb', 'mysql']] $import_schema,
   Enum['mysql']                              $db_type,
+  String                                     $db_resource_name,
   Stdlib::Host                               $db_host,
   String                                     $db_name,
   String                                     $db_username,
@@ -158,7 +162,7 @@ class icingaweb2::module::vspheredb (
       'section_name' => 'db',
       'target'       => "${module_conf_dir}/config.ini",
       'settings'     => {
-        'resource' => 'icingaweb2-module-vspheredb',
+        'resource' => $db_resource_name,
       },
     },
   }

--- a/manifests/module/vspheredb/config.pp
+++ b/manifests/module/vspheredb/config.pp
@@ -11,6 +11,7 @@ class icingaweb2::module::vspheredb::config {
   $mysql_schema    = "${icingaweb2::module::vspheredb::module_dir}${icingaweb2::globals::mysql_vspheredb_schema}"
   $pgsql_schema    = "${icingaweb2::module::vspheredb::module_dir}${icingaweb2::globals::pgsql_vspheredb_schema}"
   $db              = $icingaweb2::module::vspheredb::db
+  $db_resource     = $icingaweb2::module::vspheredb::db_resource_name
   $import_schema   = $icingaweb2::module::vspheredb::import_schema
   $use_tls         = $icingaweb2::module::vspheredb::use_tls
   $tls             = $icingaweb2::module::vspheredb::tls + {
@@ -50,7 +51,7 @@ class icingaweb2::module::vspheredb::config {
     }
   }
 
-  icingaweb2::resource::database { 'icingaweb2-module-vspheredb':
+  icingaweb2::resource::database { $db_resource:
     type         => $db['type'],
     host         => $db['host'],
     port         => $db['port'],

--- a/manifests/module/x509.pp
+++ b/manifests/module/x509.pp
@@ -21,6 +21,9 @@
 # @param db_type
 #   The database type. Either mysql or pgsql.
 #
+# @param db_resource_name
+#   Name for the x509 database resource.
+#
 # @param db_host
 #   The host where the database will be running
 #
@@ -109,6 +112,7 @@ class icingaweb2::module::x509 (
   String                                     $service_user,
   Variant[Boolean, Enum['mariadb', 'mysql']] $import_schema,
   Enum['mysql', 'pgsql']                     $db_type,
+  String                                     $db_resource_name,
   Stdlib::Host                               $db_host,
   String                                     $db_name,
   String                                     $db_username,
@@ -158,7 +162,7 @@ class icingaweb2::module::x509 (
       'section_name' => 'backend',
       'target'       => "${module_conf_dir}/config.ini",
       'settings'     => {
-        'resource' => 'x509',
+        'resource' => $db_resource_name,
       },
     },
   }

--- a/manifests/module/x509/config.pp
+++ b/manifests/module/x509/config.pp
@@ -9,6 +9,7 @@ class icingaweb2::module::x509::config {
   $icingacli_bin  = $icingaweb2::globals::icingacli_bin
   $install_method = $icingaweb2::module::x509::install_method
   $db             = $icingaweb2::module::x509::db
+  $db_resource    = $icingaweb2::module::x509::db_resource_name
   $import_schema  = $icingaweb2::module::x509::import_schema
   $use_tls        = $icingaweb2::module::x509::use_tls
   $tls            = $icingaweb2::module::x509::tls + {
@@ -45,7 +46,7 @@ class icingaweb2::module::x509::config {
     }
   }
 
-  icingaweb2::resource::database { 'x509':
+  icingaweb2::resource::database { $db_resource:
     type         => $db['type'],
     host         => $db['host'],
     port         => $db['port'],

--- a/spec/classes/icingaweb2_spec.rb
+++ b/spec/classes/icingaweb2_spec.rb
@@ -7,7 +7,7 @@ describe('icingaweb2', type: :class) do
         facts
       end
 
-      context 'with defaults' do
+      context "#{os} with db_type 'mysql'" do
         let(:params) { { db_type: 'mysql' } }
 
         it { is_expected.to compile }
@@ -52,7 +52,7 @@ describe('icingaweb2', type: :class) do
               {
                 'show_stacktraces' => false,
                  'module_path' => '/usr/share/icingaweb2/modules',
-                 'config_resource' => 'mysql-icingaweb2',
+                 'config_resource' => 'icingaweb2',
               },
             )
         }
@@ -70,19 +70,32 @@ describe('icingaweb2', type: :class) do
         it { is_expected.not_to contain_icingaweb2__inisection('config-authentication') }
         it { is_expected.not_to contain_icingaweb2__inisection('config-cookie') }
         it {
-          is_expected.to contain_icingaweb2__resource__database('mysql-icingaweb2')
+          is_expected.to contain_icingaweb2__resource__database('icingaweb2')
             .with_type('mysql')
             .with_host('localhost')
             .with_port(3306)
             .with_database('icingaweb2')
             .with_username('icingaweb2')
         }
+
+        it {
+          is_expected.to contain_icingaweb2__config__authmethod('mysql-auth')
+            .with_backend('db')
+            .with_resource('icingaweb2')
+        }
+
+        it {
+          is_expected.to contain_icingaweb2__config__groupbackend('mysql-group')
+            .with_backend('db')
+            .with_resource('icingaweb2')
+        }
+
         it { is_expected.not_to contain_exec('import schema') }
         it { is_expected.not_to contain_exec('create default admin user') }
         it { is_expected.not_to contain_icingaweb2__config__role('default admin user') }
       end
 
-      context "with manage_package 'false', cookie_path '/foo/bar', default_domain 'foobar'" do
+      context "#{os} with manage_package 'false', cookie_path '/foo/bar', default_domain 'foobar'" do
         let(:params) do
           {
             manage_package: false,
@@ -107,7 +120,7 @@ describe('icingaweb2', type: :class) do
         }
       end
 
-      context 'with additional resources, user and group backend' do
+      context '#{os} with additional resources, user and group backend' do
         let(:params) do
           {
             db_type: 'mysql',
@@ -130,22 +143,46 @@ describe('icingaweb2', type: :class) do
         it { is_expected.to contain_icingaweb2__config__groupbackend('bar').with('resource' => 'foo') }
       end
 
-      context "with db_type 'mysql', import_schema 'true'" do
+      context "#{os} with db_type 'mysql', import_schema 'true'" do
         let(:params) { { import_schema: true, db_type: 'mysql' } }
 
-        it { is_expected.to contain_icingaweb2__resource__database('mysql-icingaweb2') }
+        it { is_expected.to contain_icingaweb2__resource__database('icingaweb2') }
         it { is_expected.to contain_icingaweb2__config__authmethod('mysql-auth') }
         it { is_expected.to contain_icingaweb2__config__role('default admin user') }
         it { is_expected.to contain_exec('import schema') }
         it { is_expected.to contain_exec('create default admin user') }
       end
 
-      context "with db_type 'pgsql', import_schema 'true'" do
-        let(:params) { { import_schema: true, db_type: 'pgsql' } }
+      context "#{os} with db_type 'pgsql', db_resource_name 'foobar', import_schema 'true'" do
+        let(:params) { {  db_type: 'pgsql', import_schema: true, db_resource_name: 'foobar' } }
 
-        it { is_expected.to contain_icingaweb2__resource__database('pgsql-icingaweb2') }
-        it { is_expected.to contain_icingaweb2__config__authmethod('pgsql-auth') }
+        it {
+          is_expected.to contain_icingaweb2__inisection('config-global')
+            .with_section_name('global')
+            .with_target('/etc/icingaweb2/config.ini')
+            .with_settings(
+              {
+                'show_stacktraces' => false,
+                 'module_path' => '/usr/share/icingaweb2/modules',
+                 'config_resource' => 'foobar',
+              },
+            )
+        }
+
+        it {
+          is_expected.to contain_icingaweb2__config__authmethod('pgsql-auth')
+            .with_backend('db')
+            .with_resource('foobar')
+        }
+
+        it {
+          is_expected.to contain_icingaweb2__config__groupbackend('pgsql-group')
+            .with_backend('db')
+            .with_resource('foobar')
+        }
+
         it { is_expected.to contain_icingaweb2__config__role('default admin user') }
+        it { is_expected.to contain_icingaweb2__resource__database('foobar') }
         it { is_expected.to contain_exec('import schema') }
         it { is_expected.to contain_exec('create default admin user') }
       end

--- a/spec/classes/modules/director_spec.rb
+++ b/spec/classes/modules/director_spec.rb
@@ -30,7 +30,7 @@ describe('icingaweb2::module::director', type: :class) do
         end
 
         it {
-          is_expected.to contain_icingaweb2__resource__database('icingaweb2-module-director')
+          is_expected.to contain_icingaweb2__resource__database('director')
             .with_type('mysql')
             .with_host('localhost')
             .with_database('director')
@@ -50,7 +50,7 @@ describe('icingaweb2::module::director', type: :class) do
           is_expected.to contain_icingaweb2__inisection('module-director-db')
             .with_section_name('db')
             .with_target('/etc/icingaweb2/modules/director/config.ini')
-            .with_settings({ 'resource' => 'icingaweb2-module-director' })
+            .with_settings({ 'resource' => 'director' })
         }
 
         it {
@@ -84,10 +84,11 @@ describe('icingaweb2::module::director', type: :class) do
         it { is_expected.to contain_exec('director-kickstart') }
       end
 
-      context "#{os} with import_schema 'false', install_method 'package', manage_service 'false'" do
+      context "#{os} with db_resource_name 'foobaz', import_schema 'false', install_method 'package', manage_service 'false'" do
         let(:params) do
           { git_revision: 'foobar',
             db_type: 'mysql',
+            db_resource_name: 'foobaz',
             db_host: 'localhost',
             db_name: 'director',
             db_username: 'director',
@@ -98,7 +99,14 @@ describe('icingaweb2::module::director', type: :class) do
         end
 
         it {
-          is_expected.to contain_icingaweb2__resource__database('icingaweb2-module-director')
+          is_expected.to contain_icingaweb2__inisection('module-director-db')
+            .with_section_name('db')
+            .with_target('/etc/icingaweb2/modules/director/config.ini')
+            .with_settings({ 'resource' => 'foobaz' })
+        }
+
+        it {
+          is_expected.to contain_icingaweb2__resource__database('foobaz')
             .with_type('mysql')
             .with_host('localhost')
             .with_database('director')
@@ -146,7 +154,7 @@ describe('icingaweb2::module::director', type: :class) do
         end
 
         it {
-          is_expected.to contain_icingaweb2__resource__database('icingaweb2-module-director').with(
+          is_expected.to contain_icingaweb2__resource__database('director').with(
             {
               'type' => 'pgsql',
               'host' => 'localhost',
@@ -179,7 +187,7 @@ describe('icingaweb2::module::director', type: :class) do
         end
 
         it {
-          is_expected.to contain_icingaweb2__resource__database('icingaweb2-module-director').with(
+          is_expected.to contain_icingaweb2__resource__database('director').with(
             {
               'type' => 'mysql',
               'host' => 'localhost',

--- a/spec/classes/modules/icingadb_spec.rb
+++ b/spec/classes/modules/icingadb_spec.rb
@@ -32,7 +32,7 @@ describe('icingaweb2::module::icingadb', type: :class) do
           is_expected.to contain_icingaweb2__inisection('icingaweb2-module-icingadb-config')
             .with_section_name('icingadb')
             .with_target('/etc/icingaweb2/modules/icingadb/config.ini')
-            .with_settings({ 'resource' => 'icingaweb2-module-icingadb' })
+            .with_settings({ 'resource' => 'icingadb' })
         }
 
         it {
@@ -57,7 +57,7 @@ describe('icingaweb2::module::icingadb', type: :class) do
         }
 
         it {
-          is_expected.to contain_icingaweb2__resource__database('icingaweb2-module-icingadb').with(
+          is_expected.to contain_icingaweb2__resource__database('icingadb').with(
             {
               'type' => 'mysql',
               'host' => 'localhost',
@@ -71,7 +71,7 @@ describe('icingaweb2::module::icingadb', type: :class) do
         }
       end
 
-      context "#{os} with local PostgreSQL and two Redis with TLS, different ports and own passwords" do
+      context "#{os} with local PostgreSQL, db_resource_name 'foobaz'  and two Redis with TLS, different ports and own passwords" do
         let(:pre_condition) do
           [
             "class { 'icingaweb2': db_type => 'pgsql', tls_cacert_file => '/foo/bar' }",
@@ -81,6 +81,7 @@ describe('icingaweb2::module::icingadb', type: :class) do
         let(:params) do
           {
             db_type: 'pgsql',
+            db_resource_name: 'foobaz',
             redis_use_tls: true,
             redis_primary_host: 'redis1.icinga.com',
             redis_primary_port: 4711,
@@ -90,6 +91,13 @@ describe('icingaweb2::module::icingadb', type: :class) do
             redis_secondary_password: 'secret2',
           }
         end
+
+        it {
+          is_expected.to contain_icingaweb2__inisection('icingaweb2-module-icingadb-config')
+            .with_section_name('icingadb')
+            .with_target('/etc/icingaweb2/modules/icingadb/config.ini')
+            .with_settings({ 'resource' => 'foobaz' })
+        }
 
         it {
           is_expected.to contain_icingaweb2__inisection('icingaweb2-module-icingadb-redis')
@@ -113,7 +121,7 @@ describe('icingaweb2::module::icingadb', type: :class) do
         }
 
         it {
-          is_expected.to contain_icingaweb2__resource__database('icingaweb2-module-icingadb').with(
+          is_expected.to contain_icingaweb2__resource__database('foobaz').with(
             {
               'type' => 'pgsql',
               'host' => 'localhost',
@@ -143,7 +151,7 @@ describe('icingaweb2::module::icingadb', type: :class) do
         end
 
         it {
-          is_expected.to contain_icingaweb2__resource__database('icingaweb2-module-icingadb').with(
+          is_expected.to contain_icingaweb2__resource__database('icingadb').with(
             {
               'type' => 'mysql',
               'host' => 'localhost',
@@ -180,7 +188,7 @@ describe('icingaweb2::module::icingadb', type: :class) do
         end
 
         it {
-          is_expected.to contain_icingaweb2__resource__database('icingaweb2-module-icingadb').with(
+          is_expected.to contain_icingaweb2__resource__database('icingadb').with(
             {
               'type' => 'pgsql',
               'host' => 'localhost',

--- a/spec/classes/modules/monitoring_spec.rb
+++ b/spec/classes/modules/monitoring_spec.rb
@@ -38,7 +38,7 @@ describe('icingaweb2::module::monitoring', type: :class) do
           is_expected.to contain_icingaweb2__inisection('module-monitoring-backends')
             .with_section_name('backends')
             .with_target('/etc/icingaweb2/modules/monitoring/backends.ini')
-            .with_settings({ 'type' => 'ido', 'resource' => 'icingaweb2-module-monitoring' })
+            .with_settings({ 'type' => 'ido', 'resource' => 'icinga2' })
         }
 
         it {
@@ -49,7 +49,7 @@ describe('icingaweb2::module::monitoring', type: :class) do
         }
 
         it {
-          is_expected.to contain_icingaweb2__resource__database('icingaweb2-module-monitoring')
+          is_expected.to contain_icingaweb2__resource__database('icinga2')
             .with_type('mysql')
             .with_host('localhost')
             .with_port(4711)
@@ -65,9 +65,10 @@ describe('icingaweb2::module::monitoring', type: :class) do
         }
       end
 
-      context "#{os} with ido_type 'pgsql' and commandtransport 'local'" do
+      context "#{os} with ido_type 'pgsql', ido_resource_name 'foobar'  and commandtransport 'local'" do
         let(:params) do
           { ido_type: 'pgsql',
+            ido_resource_name: 'foobar',
             ido_host: 'localhost',
             ido_db_name: 'icinga2',
             ido_db_username: 'icinga2',
@@ -80,7 +81,14 @@ describe('icingaweb2::module::monitoring', type: :class) do
         end
 
         it {
-          is_expected.to contain_icingaweb2__resource__database('icingaweb2-module-monitoring')
+          is_expected.to contain_icingaweb2__inisection('module-monitoring-backends')
+            .with_section_name('backends')
+            .with_target('/etc/icingaweb2/modules/monitoring/backends.ini')
+            .with_settings({ 'type' => 'ido', 'resource' => 'foobar' })
+        }
+
+        it {
+          is_expected.to contain_icingaweb2__resource__database('foobar')
             .with_type('pgsql')
             .with_host('localhost')
             .with_database('icinga2')
@@ -143,7 +151,7 @@ describe('icingaweb2::module::monitoring', type: :class) do
         end
 
         it {
-          is_expected.to contain_icingaweb2__resource__database('icingaweb2-module-monitoring').with(
+          is_expected.to contain_icingaweb2__resource__database('icinga2').with(
             {
               'type' => 'pgsql',
               'host' => 'localhost',
@@ -174,7 +182,7 @@ describe('icingaweb2::module::monitoring', type: :class) do
         end
 
         it {
-          is_expected.to contain_icingaweb2__resource__database('icingaweb2-module-monitoring').with(
+          is_expected.to contain_icingaweb2__resource__database('icinga2').with(
             {
               'type' => 'mysql',
               'host' => 'localhost',

--- a/spec/classes/modules/reporting_spec.rb
+++ b/spec/classes/modules/reporting_spec.rb
@@ -157,7 +157,7 @@ describe('icingaweb2::module::reporting', type: :class) do
         }
       end
 
-      context "#{os} with db_type 'pgsql', use_tls 'true', import_schema 'true', service_ensure 'stopped', service_enabe 'false'" do
+      context "#{os} with db_type 'pgsql', db_resource_name 'foobaz', use_tls 'true', import_schema 'true', service_ensure 'stopped', service_enabe 'false'" do
         let(:pre_condition) do
           [
             "class { 'icingaweb2': db_type => 'pgsql', tls_cacert_file => '/foo/bar', tls_capath => '/foo/bar', tls_noverify => true, tls_cipher => 'cipher' }",
@@ -167,6 +167,7 @@ describe('icingaweb2::module::reporting', type: :class) do
         let(:params) do
           {
             db_type: 'pgsql',
+            db_resource_name: 'foobaz',
             db_password: 'foo',
             import_schema: true,
             use_tls: true,
@@ -176,7 +177,14 @@ describe('icingaweb2::module::reporting', type: :class) do
         end
 
         it {
-          is_expected.to contain_icingaweb2__resource__database('reporting').with(
+          is_expected.to contain_icingaweb2__inisection('icingaweb2-module-reporting-backend')
+            .with_section_name('backend')
+            .with_target('/etc/icingaweb2/modules/reporting/config.ini')
+            .with_settings({ 'resource' => 'foobaz' })
+        }
+
+        it {
+          is_expected.to contain_icingaweb2__resource__database('foobaz').with(
             {
               'type' => 'pgsql',
               'host' => 'localhost',

--- a/spec/classes/modules/vspheredb_spec.rb
+++ b/spec/classes/modules/vspheredb_spec.rb
@@ -24,7 +24,7 @@ describe('icingaweb2::module::vspheredb', type: :class) do
         end
 
         it {
-          is_expected.to contain_icingaweb2__resource__database('icingaweb2-module-vspheredb')
+          is_expected.to contain_icingaweb2__resource__database('vspheredb')
             .with_type('mysql')
             .with_host('localhost')
             .with_database('vspheredb')
@@ -44,7 +44,7 @@ describe('icingaweb2::module::vspheredb', type: :class) do
           is_expected.to contain_icingaweb2__inisection('icingaweb2-module-vspheredb')
             .with_section_name('db')
             .with_target('/etc/icingaweb2/modules/vspheredb/config.ini')
-            .with_settings({ 'resource' => 'icingaweb2-module-vspheredb' })
+            .with_settings({ 'resource' => 'vspheredb' })
         }
 
         it {
@@ -75,12 +75,13 @@ describe('icingaweb2::module::vspheredb', type: :class) do
         it { is_expected.not_to contain_exec('import icingaweb2::module::vspheredb schema') }
       end
 
-      context "#{os} with db_type 'mysql', db_port '4711', install_method 'package', manage_service 'false', import_schema 'true'" do
+      context "#{os} with db_type 'mysql', db_resource_name 'foobaz', db_port '4711', install_method 'package', manage_service 'false', import_schema 'true'" do
         let(:params) do
           {
             install_method: 'package',
             manage_service: false,
             db_type: 'mysql',
+            db_resource_name: 'foobaz',
             db_port: 4711,
             import_schema: true,
           }
@@ -92,7 +93,14 @@ describe('icingaweb2::module::vspheredb', type: :class) do
         }
 
         it {
-          is_expected.to contain_icingaweb2__resource__database('icingaweb2-module-vspheredb')
+          is_expected.to contain_icingaweb2__inisection('icingaweb2-module-vspheredb')
+            .with_section_name('db')
+            .with_target('/etc/icingaweb2/modules/vspheredb/config.ini')
+            .with_settings({ 'resource' => 'foobaz' })
+        }
+
+        it {
+          is_expected.to contain_icingaweb2__resource__database('foobaz')
             .with_type('mysql')
             .with_host('localhost')
             .with_port(4711)
@@ -139,7 +147,7 @@ describe('icingaweb2::module::vspheredb', type: :class) do
         end
 
         it {
-          is_expected.to contain_icingaweb2__resource__database('icingaweb2-module-vspheredb').with(
+          is_expected.to contain_icingaweb2__resource__database('vspheredb').with(
             {
               'type' => 'mysql',
               'host' => 'localhost',
@@ -172,7 +180,7 @@ describe('icingaweb2::module::vspheredb', type: :class) do
         end
 
         it {
-          is_expected.to contain_icingaweb2__resource__database('icingaweb2-module-vspheredb').with(
+          is_expected.to contain_icingaweb2__resource__database('vspheredb').with(
             {
               'type' => 'mysql',
               'host' => 'localhost',

--- a/spec/classes/modules/x509_spec.rb
+++ b/spec/classes/modules/x509_spec.rb
@@ -120,10 +120,11 @@ describe('icingaweb2::module::x509', type: :class) do
         it { is_expected.not_to contain_service('icinga-x509') }
       end
 
-      context "#{os} with use_tls 'true', tls_cacert 'cacert', tls_capath '/foo/bar', tls_noverify 'true', tls_cipher 'cipher'" do
+      context "#{os} with db_resource_name 'foobaz', use_tls 'true', tls_cacert 'cacert', tls_capath '/foo/bar', tls_noverify 'true', tls_cipher 'cipher'" do
         let(:params) do
           {
             db_type: 'mysql',
+            db_resource_name: 'foobaz',
             use_tls: true,
             tls_cacert_file: '/foo/bar',
             tls_capath: '/foo/bar',
@@ -133,7 +134,14 @@ describe('icingaweb2::module::x509', type: :class) do
         end
 
         it {
-          is_expected.to contain_icingaweb2__resource__database('x509').with(
+          is_expected.to contain_icingaweb2__inisection('icingaweb2-module-x509-backend')
+            .with_section_name('backend')
+            .with_target('/etc/icingaweb2/modules/x509/config.ini')
+            .with_settings({ 'resource' => 'foobaz' })
+        }
+
+        it {
+          is_expected.to contain_icingaweb2__resource__database('foobaz').with(
             {
               'type' => 'mysql',
               'host' => 'localhost',


### PR DESCRIPTION
So that we change the default resource names of
- the icingaweb2 to icingaweb2 (db_resource_name)
- the icingadb to icingadb (db_resource_name)
- the monitoring module  to icinga2 (Ido_resource_name)
- the director module to director (db_resource_name)
- the vsheredb module to vspheredb (db_resource_name)