### PR TITLE
Parameters host and port are optional for resource::database

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -5004,16 +5004,20 @@ Set database type to connect.
 
 ##### <a name="-icingaweb2--resource--database--host"></a>`host`
 
-Data type: `Stdlib::Host`
+Data type: `Optional[Stdlib::Host]`
 
 Connect to the database on the given host. For using unix domain sockets, specify 'localhost' for
 MySQL and the path to the unix domain socket and the directory for PostgreSQL.
 
+Default value: `undef`
+
 ##### <a name="-icingaweb2--resource--database--port"></a>`port`
 
-Data type: `Stdlib::Port`
+Data type: `Optional[Stdlib::Port]`
 
 Port number to use.
+
+Default value: `undef`
 
 ##### <a name="-icingaweb2--resource--database--database"></a>`database`
 

--- a/manifests/resource/database.pp
+++ b/manifests/resource/database.pp
@@ -62,10 +62,10 @@
 define icingaweb2::resource::database (
   Enum['mysql', 'pgsql', 'mssql',
   'oci', 'oracle', 'ibm', 'sqlite']  $type,
-  Stdlib::Host                       $host,
   String                             $database,
-  Stdlib::Port                       $port,
   String                             $resource_name = $title,
+  Optional[Stdlib::Host]             $host          = undef,
+  Optional[Stdlib::Port]             $port          = undef,
   Optional[String]                   $username      = undef,
   Optional[Icingaweb2::Secret]       $password      = undef,
   Optional[String]                   $charset       = undef,


### PR DESCRIPTION
For Oracle (type: oct or oracle) databases that use a listener (TNS) do not require a host.