### PR TITLE
Remove config_backend from examples

### DIFF
--- a/examples/director-mysql.pp
+++ b/examples/director-mysql.pp
@@ -17,7 +17,6 @@ class { 'icingaweb2':
   db_type                => 'mysql',
   db_password            => $db_password,
   import_schema          => true,
-  config_backend         => 'db',
   default_admin_username => 'icingaadmin',
   default_admin_password => 'icinga',
   require                => Mysql::Db['icingaweb2'],

--- a/examples/director-pgsql.pp
+++ b/examples/director-pgsql.pp
@@ -15,7 +15,6 @@ class { 'icingaweb2':
   db_type                => 'pgsql',
   db_password            => $db_password,
   import_schema          => true,
-  config_backend         => 'db',
   default_admin_username => 'icingaadmin',
   default_admin_password => 'icinga',
   require                => Postgresql::Server::Db['icingaweb2'],

--- a/examples/icingadb-mysql.pp
+++ b/examples/icingadb-mysql.pp
@@ -14,7 +14,6 @@ class { 'icingaweb2':
   db_type                => 'mysql',
   db_password            => $db_password,
   import_schema          => true,
-  config_backend         => 'db',
   default_admin_username => 'icingaadmin',
   default_admin_password => 'icinga',
   require                => Mysql::Db['icingaweb2'],

--- a/examples/icingadb-pgsql.pp
+++ b/examples/icingadb-pgsql.pp
@@ -25,7 +25,6 @@ class { 'icingaweb2':
   db_type                => 'pgsql',
   db_password            => $db_password,
   import_schema          => true,
-  config_backend         => 'db',
   default_admin_username => 'icingaadmin',
   default_admin_password => 'icinga',
   require                => Postgresql::Server::Db['icingaweb2'],

--- a/examples/icingaweb2-mysql.pp
+++ b/examples/icingaweb2-mysql.pp
@@ -14,7 +14,6 @@ class { 'icingaweb2':
   db_type                => 'mysql',
   db_password            => $db_password,
   import_schema          => true,
-  config_backend         => 'db',
   default_admin_username => 'icingaadmin',
   default_admin_password => 'icinga',
   require                => Mysql::Db['icingaweb2'],

--- a/examples/icingaweb2-pgsql.pp
+++ b/examples/icingaweb2-pgsql.pp
@@ -25,7 +25,6 @@ class { 'icingaweb2':
   db_type                => 'pgsql',
   db_password            => $db_password,
   import_schema          => true,
-  config_backend         => 'db',
   default_admin_username => 'icingaadmin',
   default_admin_password => 'icinga',
   require                => Postgresql::Server::Db['icingaweb2'],

--- a/examples/idoreports-mysql.pp
+++ b/examples/idoreports-mysql.pp
@@ -29,7 +29,6 @@ class { 'icingaweb2':
   db_type                => 'mysql',
   db_password            => $db_password,
   import_schema          => true,
-  config_backend         => 'db',
   default_admin_username => 'icingaadmin',
   default_admin_password => 'icinga',
   require                => Mysql::Db['icingaweb2'],

--- a/examples/idoreports-pgsql.pp
+++ b/examples/idoreports-pgsql.pp
@@ -27,7 +27,6 @@ class { 'icingaweb2':
   db_type                => 'pgsql',
   db_password            => $db_password,
   import_schema          => true,
-  config_backend         => 'db',
   default_admin_username => 'icingaadmin',
   default_admin_password => 'icinga',
   require                => Postgresql::Server::Db['icingaweb2'],

--- a/examples/monitoring-mysql.pp
+++ b/examples/monitoring-mysql.pp
@@ -14,7 +14,6 @@ class { 'icingaweb2':
   db_type                => 'mysql',
   db_password            => $db_password,
   import_schema          => true,
-  config_backend         => 'db',
   default_admin_username => 'icingaadmin',
   default_admin_password => 'icinga',
   require                => Mysql::Db['icingaweb2'],

--- a/examples/monitoring-pgsql.pp
+++ b/examples/monitoring-pgsql.pp
@@ -25,7 +25,6 @@ class { 'icingaweb2':
   db_type                => 'pgsql',
   db_password            => $db_password,
   import_schema          => true,
-  config_backend         => 'db',
   default_admin_username => 'icingaadmin',
   default_admin_password => 'icinga',
   require                => Postgresql::Server::Db['icingaweb2'],

--- a/examples/reporting-mysql.pp
+++ b/examples/reporting-mysql.pp
@@ -29,7 +29,6 @@ class { 'icingaweb2':
   db_type                => 'mysql',
   db_password            => $db_password,
   import_schema          => true,
-  config_backend         => 'db',
   default_admin_username => 'icingaadmin',
   default_admin_password => 'icinga',
   require                => Mysql::Db['icingaweb2'],

--- a/examples/reporting-pgsql.pp
+++ b/examples/reporting-pgsql.pp
@@ -27,7 +27,6 @@ class { 'icingaweb2':
   db_type                => 'pgsql',
   db_password            => $db_password,
   import_schema          => true,
-  config_backend         => 'db',
   default_admin_username => 'icingaadmin',
   default_admin_password => 'icinga',
   require                => Postgresql::Server::Db['icingaweb2'],

--- a/examples/x509-mysql.pp
+++ b/examples/x509-mysql.pp
@@ -14,7 +14,6 @@ class { 'icingaweb2':
   db_type                => 'mysql',
   db_password            => $db_password,
   import_schema          => true,
-  config_backend         => 'db',
   default_admin_username => 'icingaadmin',
   default_admin_password => 'icinga',
   require                => Mysql::Db['icingaweb2'],

--- a/examples/x509-pgsql.pp
+++ b/examples/x509-pgsql.pp
@@ -12,7 +12,6 @@ class { 'icingaweb2':
   db_type                => 'pgsql',
   db_password            => $db_password,
   import_schema          => true,
-  config_backend         => 'db',
   default_admin_username => 'icingaadmin',
   default_admin_password => 'icinga',
   require                => Postgresql::Server::Db['icingaweb2'],


### PR DESCRIPTION
Parameter `config_backend` has been removed in #373.